### PR TITLE
Remove duplicate try/catch block

### DIFF
--- a/src/test/java/se/citerus/dddsample/domain/model/voyage/CarrierMovementTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/voyage/CarrierMovementTest.java
@@ -15,11 +15,6 @@ public class CarrierMovementTest extends TestCase {
     } catch (IllegalArgumentException expected) {}
 
     try {
-      new CarrierMovement(null, null, new Date(), new Date());
-      fail("Should not accept null constructor arguments");
-    } catch (IllegalArgumentException expected) {}
-
-    try {
       new CarrierMovement(STOCKHOLM, null, new Date(), new Date());
       fail("Should not accept null constructor arguments");
     } catch (IllegalArgumentException expected) {}


### PR DESCRIPTION
I think this might be a leftover from when `CarrierMovement` used to have five constructor parameters (`CarrierMovementId` was removed somewhere down the road). :-)
