### PR TITLE
Use JUnit4 style for all tests

### DIFF
--- a/src/test/java/se/citerus/dddsample/acceptance/AbstractAcceptanceTest.java
+++ b/src/test/java/se/citerus/dddsample/acceptance/AbstractAcceptanceTest.java
@@ -6,12 +6,13 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriverBuilder;
 import org.springframework.web.context.WebApplicationContext;
+
 import se.citerus.dddsample.Application;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
 public abstract class AbstractAcceptanceTest {
 

--- a/src/test/java/se/citerus/dddsample/application/BookingServiceTest.java
+++ b/src/test/java/se/citerus/dddsample/application/BookingServiceTest.java
@@ -1,6 +1,20 @@
 package se.citerus.dddsample.application;
 
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.CHICAGO;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
+
+import java.util.Date;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import se.citerus.dddsample.application.impl.BookingServiceImpl;
 import se.citerus.dddsample.domain.model.cargo.Cargo;
 import se.citerus.dddsample.domain.model.cargo.CargoRepository;
@@ -9,27 +23,22 @@ import se.citerus.dddsample.domain.model.location.LocationRepository;
 import se.citerus.dddsample.domain.model.location.UnLocode;
 import se.citerus.dddsample.domain.service.RoutingService;
 
-import java.util.Date;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.easymock.EasyMock.*;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.CHICAGO;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
-
-public class BookingServiceTest extends TestCase {
+public class BookingServiceTest {
 
   BookingServiceImpl bookingService;
   CargoRepository cargoRepository;
   LocationRepository locationRepository;
   RoutingService routingService;
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() {
     cargoRepository = createMock(CargoRepository.class);
     locationRepository = createMock(LocationRepository.class);
     routingService = createMock(RoutingService.class);
     bookingService = new BookingServiceImpl(cargoRepository, locationRepository, routingService);
   }
 
+  @Test
   public void testRegisterNew() {
     TrackingId expectedTrackingId = new TrackingId("TRK1");
     UnLocode fromUnlocode = new UnLocode("USCHI");
@@ -47,7 +56,8 @@ public class BookingServiceTest extends TestCase {
     assertThat(trackingId).isEqualTo(expectedTrackingId);
   }
 
-  protected void tearDown() throws Exception {
+  @After
+  public void tearDown() {
     verify(cargoRepository, locationRepository);
   }
 }

--- a/src/test/java/se/citerus/dddsample/application/HandlingEventServiceTest.java
+++ b/src/test/java/se/citerus/dddsample/application/HandlingEventServiceTest.java
@@ -1,7 +1,21 @@
 package se.citerus.dddsample.application;
 
-import junit.framework.TestCase;
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HAMBURG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.TOKYO;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
+
+import java.util.Date;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import se.citerus.dddsample.application.impl.HandlingEventServiceImpl;
 import se.citerus.dddsample.domain.model.cargo.Cargo;
 import se.citerus.dddsample.domain.model.cargo.CargoRepository;
@@ -11,13 +25,9 @@ import se.citerus.dddsample.domain.model.handling.HandlingEvent;
 import se.citerus.dddsample.domain.model.handling.HandlingEventFactory;
 import se.citerus.dddsample.domain.model.handling.HandlingEventRepository;
 import se.citerus.dddsample.domain.model.location.LocationRepository;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
 import se.citerus.dddsample.domain.model.voyage.VoyageRepository;
 
-import java.util.Date;
-
-public class HandlingEventServiceTest extends TestCase {
+public class HandlingEventServiceTest {
   private HandlingEventServiceImpl service;
   private ApplicationEvents applicationEvents;
   private CargoRepository cargoRepository;
@@ -27,7 +37,8 @@ public class HandlingEventServiceTest extends TestCase {
 
   private final Cargo cargo = new Cargo(new TrackingId("ABC"), new RouteSpecification(HAMBURG, TOKYO, new Date()));
 
-  protected void setUp() throws Exception{
+  @Before
+  public void setUp() {
     cargoRepository = createMock(CargoRepository.class);
     voyageRepository = createMock(VoyageRepository.class);
     handlingEventRepository = createMock(HandlingEventRepository.class);
@@ -38,10 +49,12 @@ public class HandlingEventServiceTest extends TestCase {
     service = new HandlingEventServiceImpl(handlingEventRepository, applicationEvents, handlingEventFactory);
   }
 
-  protected void tearDown() throws Exception {
+  @After
+  public void tearDown() {
     verify(cargoRepository, voyageRepository, handlingEventRepository, applicationEvents);
   }
 
+  @Test
   public void testRegisterEvent() throws Exception {
     expect(cargoRepository.find(cargo.trackingId())).andReturn(cargo);
     expect(voyageRepository.find(CM001.voyageNumber())).andReturn(CM001);

--- a/src/test/java/se/citerus/dddsample/domain/model/cargo/CargoTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/cargo/CargoTest.java
@@ -1,6 +1,33 @@
 package se.citerus.dddsample.domain.model.cargo;
 
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.MISROUTED;
+import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.NOT_ROUTED;
+import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.ROUTED;
+import static se.citerus.dddsample.domain.model.cargo.TransportStatus.NOT_RECEIVED;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.GOTHENBURG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HAMBURG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HANGZOU;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HONGKONG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.MELBOURNE;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.NEWYORK;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.ROTTERDAM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.SHANGHAI;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.TOKYO;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import se.citerus.dddsample.application.util.DateTestUtil;
 import se.citerus.dddsample.domain.model.handling.HandlingEvent;
 import se.citerus.dddsample.domain.model.handling.HandlingHistory;
@@ -8,22 +35,13 @@ import se.citerus.dddsample.domain.model.location.Location;
 import se.citerus.dddsample.domain.model.voyage.Voyage;
 import se.citerus.dddsample.domain.model.voyage.VoyageNumber;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.*;
-import static se.citerus.dddsample.domain.model.cargo.TransportStatus.NOT_RECEIVED;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-
-public class CargoTest extends TestCase {
+public class CargoTest {
 
   private List<HandlingEvent> events;
   private Voyage voyage;
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() {
     events = new ArrayList<HandlingEvent>();
 
     voyage = new Voyage.Builder(new VoyageNumber("0123"), STOCKHOLM).
@@ -33,7 +51,8 @@ public class CargoTest extends TestCase {
       build();
   }
 
-  public void testConstruction() throws Exception {
+  @Test
+  public void testConstruction() {
     final TrackingId trackingId = new TrackingId("XYZ");
     final Date arrivalDeadline = DateTestUtil.toDate("2009-03-13");
     final RouteSpecification routeSpecification = new RouteSpecification(
@@ -48,7 +67,8 @@ public class CargoTest extends TestCase {
     assertThat(cargo.delivery().currentVoyage()).isEqualTo(Voyage.NONE);    
   }
 
-  public void testRoutingStatus() throws Exception {
+  @Test
+  public void testRoutingStatus() {
     final Cargo cargo = new Cargo(new TrackingId("XYZ"), new RouteSpecification(STOCKHOLM, MELBOURNE, new Date()));
     final Itinerary good = new Itinerary();
     final Itinerary bad = new Itinerary();
@@ -70,37 +90,43 @@ public class CargoTest extends TestCase {
     assertThat(cargo.delivery().routingStatus()).isEqualTo(ROUTED);
   }
 
-  public void testlastKnownLocationUnknownWhenNoEvents() throws Exception {
+  @Test
+  public void testlastKnownLocationUnknownWhenNoEvents() {
     Cargo cargo = new Cargo(new TrackingId("XYZ"), new RouteSpecification(STOCKHOLM, MELBOURNE, new Date()));
 
     assertThat(cargo.delivery().lastKnownLocation()).isEqualTo(Location.UNKNOWN);
   }
 
+  @Test
   public void testlastKnownLocationReceived() throws Exception {
     Cargo cargo = populateCargoReceivedStockholm();
 
     assertThat(cargo.delivery().lastKnownLocation()).isEqualTo(STOCKHOLM);
   }
 
+  @Test
   public void testlastKnownLocationClaimed() throws Exception {
     Cargo cargo = populateCargoClaimedMelbourne();
 
     assertThat(cargo.delivery().lastKnownLocation()).isEqualTo(MELBOURNE);
   }
 
+  @Test
   public void testlastKnownLocationUnloaded() throws Exception {
     Cargo cargo = populateCargoOffHongKong();
 
     assertThat(cargo.delivery().lastKnownLocation()).isEqualTo(HONGKONG);
   }
 
+  @Test
   public void testlastKnownLocationloaded() throws Exception {
     Cargo cargo = populateCargoOnHamburg();
 
     assertThat(cargo.delivery().lastKnownLocation()).isEqualTo(HAMBURG);
   }
 
-  public void testEquality() throws Exception {
+  @Test
+  public void testEquality() {
     RouteSpecification spec1 = new RouteSpecification(STOCKHOLM, HONGKONG, new Date());
     RouteSpecification spec2 = new RouteSpecification(STOCKHOLM, MELBOURNE, new Date());
     Cargo c1 = new Cargo(new TrackingId("ABC"), spec1);
@@ -114,7 +140,8 @@ public class CargoTest extends TestCase {
     assertThat(c1.equals(c2)).as("Cargos are not equal when TrackingID differ").isFalse();
   }
 
-  public void testIsUnloadedAtFinalDestination() throws Exception {
+  @Test
+  public void testIsUnloadedAtFinalDestination() {
     Cargo cargo = setUpCargoWithItinerary(HANGZOU, TOKYO, NEWYORK);
     assertThat(cargo.delivery().isUnloadedAtDestination()).isFalse();
 
@@ -223,7 +250,8 @@ public class CargoTest extends TestCase {
     return cargo;
   }
 
-  public void testIsMisdirected() throws Exception {
+  @Test
+  public void testIsMisdirected() {
     //A cargo with no itinerary is not misdirected
     Cargo cargo = new Cargo(new TrackingId("TRKID"), new RouteSpecification(SHANGHAI, GOTHENBURG, new Date()));
     assertThat(cargo.delivery().isMisdirected()).isFalse();

--- a/src/test/java/se/citerus/dddsample/domain/model/cargo/DeliveryTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/cargo/DeliveryTest.java
@@ -1,18 +1,19 @@
 package se.citerus.dddsample.domain.model.cargo;
 
-import junit.framework.TestCase;
-
-import java.util.Date;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.citerus.dddsample.domain.model.location.SampleLocations.HONGKONG;
 import static se.citerus.dddsample.domain.model.location.SampleLocations.NEWYORK;
 
-public class DeliveryTest extends TestCase {
+import java.util.Date;
+
+import org.junit.Test;
+
+public class DeliveryTest {
 
   private Cargo cargo = new Cargo(new TrackingId("XYZ"), new RouteSpecification(HONGKONG, NEWYORK, new Date()));
 
-  public void testToSilenceWarnings() throws Exception {
+  @Test
+  public void testToSilenceWarnings() {
     assertThat(true).isTrue();
   }
   

--- a/src/test/java/se/citerus/dddsample/domain/model/cargo/ItineraryTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/cargo/ItineraryTest.java
@@ -1,20 +1,29 @@
 package se.citerus.dddsample.domain.model.cargo;
 
-import junit.framework.TestCase;
-import se.citerus.dddsample.domain.model.handling.HandlingEvent;
-import se.citerus.dddsample.domain.model.voyage.CarrierMovement;
-import se.citerus.dddsample.domain.model.voyage.Voyage;
-import se.citerus.dddsample.domain.model.voyage.VoyageNumber;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.GOTHENBURG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HANGZOU;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HELSINKI;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.NEWYORK;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.ROTTERDAM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.SHANGHAI;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
+import org.junit.Before;
+import org.junit.Test;
 
-public class ItineraryTest extends TestCase {
+import se.citerus.dddsample.domain.model.handling.HandlingEvent;
+import se.citerus.dddsample.domain.model.voyage.CarrierMovement;
+import se.citerus.dddsample.domain.model.voyage.Voyage;
+import se.citerus.dddsample.domain.model.voyage.VoyageNumber;
+
+public class ItineraryTest {
   private final CarrierMovement abc = new CarrierMovement(SHANGHAI, ROTTERDAM, new Date(), new Date());
   private final CarrierMovement def = new CarrierMovement(ROTTERDAM, GOTHENBURG, new Date(), new Date());
   private final CarrierMovement ghi = new CarrierMovement(ROTTERDAM, NEWYORK, new Date(), new Date());
@@ -22,7 +31,8 @@ public class ItineraryTest extends TestCase {
 
   Voyage voyage, wrongVoyage;
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() {
     voyage = new Voyage.Builder(new VoyageNumber("0123"), SHANGHAI).
       addMovement(ROTTERDAM, new Date(), new Date()).
       addMovement(GOTHENBURG, new Date(), new Date()).
@@ -34,7 +44,8 @@ public class ItineraryTest extends TestCase {
       build();
   }
 
-  public void testCargoOnTrack() throws Exception {
+  @Test
+  public void testCargoOnTrack() {
 
     TrackingId trackingId = new TrackingId("CARGO1");
     RouteSpecification routeSpecification = new RouteSpecification(SHANGHAI, GOTHENBURG, new Date());
@@ -86,14 +97,14 @@ public class ItineraryTest extends TestCase {
     assertThat(itinerary.isExpected(event)).isFalse();
 
   }
-
-  public void testNextExpectedEvent() throws Exception {
+  @Test
+  public void testNextExpectedEvent() {
 
   }
-
-  public void testCreateItinerary() throws Exception {
+  @Test
+  public void testCreateItinerary() {
     try {
-      new Itinerary(new ArrayList<Leg>());
+      new Itinerary(new ArrayList<>());
       fail("An empty itinerary is not OK");
     } catch (IllegalArgumentException iae) {
       //Expected

--- a/src/test/java/se/citerus/dddsample/domain/model/cargo/LegTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/cargo/LegTest.java
@@ -1,10 +1,13 @@
 package se.citerus.dddsample.domain.model.cargo;
 
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.fail;
 
-public class LegTest extends TestCase {
+import org.junit.Test;
 
-  public void testConstructor() throws Exception {
+public class LegTest {
+
+  @Test
+  public void testConstructor() {
     try {
       new Leg(null,null,null,null,null);
       fail("Should not accept null constructor arguments");

--- a/src/test/java/se/citerus/dddsample/domain/model/cargo/RouteSpecificationTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/cargo/RouteSpecificationTest.java
@@ -1,16 +1,22 @@
 package se.citerus.dddsample.domain.model.cargo;
 
-import junit.framework.TestCase;
-import se.citerus.dddsample.domain.model.voyage.Voyage;
-import se.citerus.dddsample.domain.model.voyage.VoyageNumber;
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.citerus.dddsample.application.util.DateTestUtil.toDate;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.CHICAGO;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.DALLAS;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HANGZOU;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HONGKONG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.NEWYORK;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.TOKYO;
 
 import java.util.Arrays;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static se.citerus.dddsample.application.util.DateTestUtil.toDate;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
+import org.junit.Test;
 
-public class RouteSpecificationTest extends TestCase {
+import se.citerus.dddsample.domain.model.voyage.Voyage;
+import se.citerus.dddsample.domain.model.voyage.VoyageNumber;
+
+public class RouteSpecificationTest {
 
   final Voyage hongKongTokyoNewYork = new Voyage.Builder(
     new VoyageNumber("V001"), HONGKONG).
@@ -34,7 +40,7 @@ public class RouteSpecificationTest extends TestCase {
       new Leg(dallasNewYorkChicago, NEWYORK, CHICAGO,
               toDate("2009-02-12"), toDate("2009-02-20")))
   );
-
+  @Test
   public void testIsSatisfiedBy_Success() {
     RouteSpecification routeSpecification = new RouteSpecification(
       HONGKONG, CHICAGO, toDate("2009-03-01")
@@ -43,6 +49,7 @@ public class RouteSpecificationTest extends TestCase {
     assertThat(routeSpecification.isSatisfiedBy(itinerary)).isTrue();
   }
 
+  @Test
   public void testIsSatisfiedBy_WrongOrigin() {
     RouteSpecification routeSpecification = new RouteSpecification(
       HANGZOU, CHICAGO, toDate("2009-03-01")
@@ -50,7 +57,7 @@ public class RouteSpecificationTest extends TestCase {
 
     assertThat(routeSpecification.isSatisfiedBy(itinerary)).isFalse();
   }
-
+  @Test
   public void testIsSatisfiedBy_WrongDestination() {
     RouteSpecification routeSpecification = new RouteSpecification(
       HONGKONG, DALLAS, toDate("2009-03-01")
@@ -58,7 +65,7 @@ public class RouteSpecificationTest extends TestCase {
 
     assertThat(routeSpecification.isSatisfiedBy(itinerary)).isFalse();
   }
-
+  @Test
   public void testIsSatisfiedBy_MissedDeadline() {
     RouteSpecification routeSpecification = new RouteSpecification(
       HONGKONG, CHICAGO, toDate("2009-02-15")

--- a/src/test/java/se/citerus/dddsample/domain/model/cargo/TrackingIdTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/cargo/TrackingIdTest.java
@@ -1,10 +1,13 @@
 package se.citerus.dddsample.domain.model.cargo;
 
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.fail;
 
-public class TrackingIdTest extends TestCase {
+import org.junit.Test;
 
-  public void testConstructor() throws Exception {
+public class TrackingIdTest {
+
+  @Test
+  public void testConstructor() {
     try {
       new TrackingId(null);
       fail("Should not accept null constructor arguments");

--- a/src/test/java/se/citerus/dddsample/domain/model/handling/HandlingEventFactoryTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/handling/HandlingEventFactoryTest.java
@@ -1,6 +1,23 @@
 package se.citerus.dddsample.domain.model.handling;
 
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HELSINKI;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.TOKYO;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
+
+import java.util.Date;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import se.citerus.dddsample.domain.model.cargo.Cargo;
 import se.citerus.dddsample.domain.model.cargo.CargoRepository;
 import se.citerus.dddsample.domain.model.cargo.RouteSpecification;
@@ -13,15 +30,7 @@ import se.citerus.dddsample.domain.model.voyage.VoyageRepository;
 import se.citerus.dddsample.infrastructure.persistence.inmemory.LocationRepositoryInMem;
 import se.citerus.dddsample.infrastructure.persistence.inmemory.VoyageRepositoryInMem;
 
-import java.util.Date;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.easymock.EasyMock.*;
-import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
-
-public class HandlingEventFactoryTest extends TestCase {
+public class HandlingEventFactoryTest {
 
   HandlingEventFactory factory;
   CargoRepository cargoRepository;
@@ -30,7 +39,8 @@ public class HandlingEventFactoryTest extends TestCase {
   TrackingId trackingId;
   Cargo cargo;
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() {
 
     cargoRepository = createMock(CargoRepository.class);
     voyageRepository = new VoyageRepositoryInMem();
@@ -44,6 +54,7 @@ public class HandlingEventFactoryTest extends TestCase {
     cargo = new Cargo(trackingId, routeSpecification);
   }
 
+  @Test
   public void testCreateHandlingEventWithCarrierMovement() throws Exception {
     expect(cargoRepository.find(trackingId)).andReturn(cargo);
 
@@ -63,6 +74,7 @@ public class HandlingEventFactoryTest extends TestCase {
     assertThat(handlingEvent.registrationTime().before(new Date(System.currentTimeMillis() + 1))).isTrue();
   }
 
+  @Test
   public void testCreateHandlingEventWithoutCarrierMovement() throws Exception {
     expect(cargoRepository.find(trackingId)).andReturn(cargo);
 
@@ -81,6 +93,7 @@ public class HandlingEventFactoryTest extends TestCase {
     assertThat(handlingEvent.registrationTime().before(new Date(System.currentTimeMillis() + 1))).isTrue();
   }
 
+  @Test
   public void testCreateHandlingEventUnknownLocation() throws Exception {
     expect(cargoRepository.find(trackingId)).andReturn(cargo);
 
@@ -95,6 +108,7 @@ public class HandlingEventFactoryTest extends TestCase {
     } catch (UnknownLocationException expected) {}
   }
 
+  @Test
   public void testCreateHandlingEventUnknownCarrierMovement() throws Exception {
     expect(cargoRepository.find(trackingId)).andReturn(cargo);
 
@@ -109,6 +123,7 @@ public class HandlingEventFactoryTest extends TestCase {
     } catch (UnknownVoyageException expected) {}
   }
 
+  @Test
   public void testCreateHandlingEventUnknownTrackingId() throws Exception {
     expect(cargoRepository.find(trackingId)).andReturn(null);
 
@@ -122,7 +137,8 @@ public class HandlingEventFactoryTest extends TestCase {
     } catch (UnknownCargoException expected) {}
   }
 
-  protected void tearDown() throws Exception {
+  @After
+  public void tearDown() {
     verify(cargoRepository);
   }
 }

--- a/src/test/java/se/citerus/dddsample/domain/model/handling/HandlingEventTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/handling/HandlingEventTest.java
@@ -1,30 +1,44 @@
 package se.citerus.dddsample.domain.model.handling;
 
-import junit.framework.TestCase;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.CLAIM;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.CUSTOMS;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.LOAD;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.RECEIVE;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.UNLOAD;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.valueOf;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.CHICAGO;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HAMBURG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HELSINKI;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HONGKONG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.NEWYORK;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM003;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM004;
+
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import se.citerus.dddsample.domain.model.cargo.Cargo;
 import se.citerus.dddsample.domain.model.cargo.RouteSpecification;
 import se.citerus.dddsample.domain.model.cargo.TrackingId;
 import se.citerus.dddsample.domain.model.voyage.SampleVoyages;
 
-import java.util.Date;
-
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.*;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM003;
-import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM004;
-
-public class HandlingEventTest extends TestCase {
+public class HandlingEventTest {
   private Cargo cargo;
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() {
     TrackingId trackingId = new TrackingId("XYZ");
     RouteSpecification routeSpecification = new RouteSpecification(HONGKONG, NEWYORK, new Date());
     cargo = new Cargo(trackingId, routeSpecification);
   }
 
-  public void testNewWithCarrierMovement() throws Exception {
+  @Test
+  public void testNewWithCarrierMovement() {
 
     HandlingEvent e1 = new HandlingEvent(cargo, new Date(), new Date(), LOAD, HONGKONG, CM003);
     assertThat(e1.location()).isEqualTo(HONGKONG);
@@ -49,43 +63,50 @@ public class HandlingEventTest extends TestCase {
     }
   }
 
-  public void testNewWithLocation() throws Exception {
+  @Test
+  public void testNewWithLocation() {
     HandlingEvent e1 = new HandlingEvent(cargo, new Date(), new Date(), HandlingEvent.Type.CLAIM, HELSINKI);
     assertThat(e1.location()).isEqualTo(HELSINKI);
   }
 
-  public void testCurrentLocationLoadEvent() throws Exception {
+  @Test
+  public void testCurrentLocationLoadEvent() {
 
     HandlingEvent ev = new HandlingEvent(cargo, new Date(), new Date(), LOAD, CHICAGO, CM004);
     
     assertThat(ev.location()).isEqualTo(CHICAGO);
   }
   
-  public void testCurrentLocationUnloadEvent() throws Exception {
+  public void testCurrentLocationUnloadEvent() {
     HandlingEvent ev = new HandlingEvent(cargo, new Date(), new Date(), UNLOAD, HAMBURG, CM004);
     
     assertThat(ev.location()).isEqualTo(HAMBURG);
   }
-  
-  public void testCurrentLocationReceivedEvent() throws Exception {
+
+  @Test
+  public void testCurrentLocationReceivedEvent() {
     HandlingEvent ev = new HandlingEvent(cargo, new Date(), new Date(), RECEIVE, CHICAGO);
 
     assertThat(ev.location()).isEqualTo(CHICAGO);
   }
-  public void testCurrentLocationClaimedEvent() throws Exception {
+
+  @Test
+  public void testCurrentLocationClaimedEvent() {
     HandlingEvent ev = new HandlingEvent(cargo, new Date(), new Date(), CLAIM, CHICAGO);
 
     assertThat(ev.location()).isEqualTo(CHICAGO);
   }
-  
-  public void testParseType() throws Exception {
+
+  @Test
+  public void testParseType() {
     assertThat(valueOf("CLAIM")).isEqualTo(CLAIM);
     assertThat(valueOf("LOAD")).isEqualTo(LOAD);
     assertThat(valueOf("UNLOAD")).isEqualTo(UNLOAD);
     assertThat(valueOf("RECEIVE")).isEqualTo(RECEIVE);
   }
-  
-  public void testParseTypeIllegal() throws Exception {
+
+  @Test
+  public void testParseTypeIllegal() {
     try {
       valueOf("NOT_A_HANDLING_EVENT_TYPE");
       fail("Expected IllegaArgumentException to be thrown");
@@ -93,8 +114,9 @@ public class HandlingEventTest extends TestCase {
       // All's well
     }
   }
-  
-  public void testEqualsAndSameAs() throws Exception {
+
+  @Test
+  public void testEqualsAndSameAs() {
     Date timeOccured = new Date();
     Date timeRegistered = new Date();
 

--- a/src/test/java/se/citerus/dddsample/domain/model/handling/HandlingHistoryTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/handling/HandlingHistoryTest.java
@@ -1,21 +1,24 @@
 package se.citerus.dddsample.domain.model.handling;
 
-import junit.framework.TestCase;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.citerus.dddsample.application.util.DateTestUtil.toDate;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.DALLAS;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HONGKONG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.SHANGHAI;
+
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import se.citerus.dddsample.domain.model.cargo.Cargo;
 import se.citerus.dddsample.domain.model.cargo.RouteSpecification;
 import se.citerus.dddsample.domain.model.cargo.TrackingId;
 import se.citerus.dddsample.domain.model.voyage.Voyage;
 import se.citerus.dddsample.domain.model.voyage.VoyageNumber;
 
-import java.util.Date;
-
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static se.citerus.dddsample.application.util.DateTestUtil.toDate;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-
-
-public class HandlingHistoryTest extends TestCase {
+public class HandlingHistoryTest {
   Cargo cargo;
   Voyage voyage;
   HandlingEvent event1;
@@ -23,7 +26,8 @@ public class HandlingHistoryTest extends TestCase {
   HandlingEvent event2;
   HandlingHistory handlingHistory;
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() {
     cargo = new Cargo(new TrackingId("ABC"), new RouteSpecification(SHANGHAI, DALLAS, toDate("2009-04-01")));
     voyage = new Voyage.Builder(new VoyageNumber("X25"), HONGKONG).
       addMovement(SHANGHAI, new Date(), new Date()).
@@ -36,10 +40,12 @@ public class HandlingHistoryTest extends TestCase {
     handlingHistory = new HandlingHistory(asList(event2, event1, event1duplicate));
   }
 
+  @Test
   public void testDistinctEventsByCompletionTime() {
     assertThat(handlingHistory.distinctEventsByCompletionTime()).isEqualTo(asList(event1, event2));
   }
 
+  @Test
   public void testMostRecentlyCompletedEvent() {
     assertThat(handlingHistory.mostRecentlyCompletedEvent()).isEqualTo(event2);
   }

--- a/src/test/java/se/citerus/dddsample/domain/model/location/LocationTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/location/LocationTest.java
@@ -1,11 +1,13 @@
 package se.citerus.dddsample.domain.model.location;
 
-import junit.framework.TestCase;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
-public class LocationTest extends TestCase {
+import org.junit.Test;
 
+public class LocationTest {
+
+  @Test
   public void testEquals() {
     // Same UN locode - equal
     assertThat(new Location(new UnLocode("ATEST"),"test-name").

--- a/src/test/java/se/citerus/dddsample/domain/model/location/UnLocodeTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/location/UnLocodeTest.java
@@ -1,12 +1,15 @@
 package se.citerus.dddsample.domain.model.location;
 
-import junit.framework.TestCase;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
-public class UnLocodeTest extends TestCase {
+import org.junit.Test;
 
-  public void testNew() throws Exception {
+public class UnLocodeTest {
+
+
+  @Test
+  public void testNew() {
     assertValid("AA234");
     assertValid("AAA9B");
     assertValid("AAAAA");
@@ -20,11 +23,13 @@ public class UnLocodeTest extends TestCase {
     assertInvalid(null);
   }
 
-  public void testIdString() throws Exception {
+  @Test
+  public void testIdString() {
     assertThat(new UnLocode("AbcDe").idString()).isEqualTo("ABCDE");
   }
 
-  public void testEquals() throws Exception {
+  @Test
+  public void testEquals() {
     UnLocode allCaps = new UnLocode("ABCDE");
     UnLocode mixedCase = new UnLocode("aBcDe");
 
@@ -36,7 +41,8 @@ public class UnLocodeTest extends TestCase {
     assertThat(allCaps.equals(new UnLocode("FGHIJ"))).isFalse();
   }
 
-  public void testHashCode() throws Exception {
+  @Test
+  public void testHashCode() {
     UnLocode allCaps = new UnLocode("ABCDE");
     UnLocode mixedCase = new UnLocode("aBcDe");
 

--- a/src/test/java/se/citerus/dddsample/domain/model/voyage/CarrierMovementTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/voyage/CarrierMovementTest.java
@@ -1,16 +1,18 @@
 package se.citerus.dddsample.domain.model.voyage;
 
-import junit.framework.TestCase;
-
-import java.util.Date;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static se.citerus.dddsample.domain.model.location.SampleLocations.HAMBURG;
 import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
 
-public class CarrierMovementTest extends TestCase {
+import java.util.Date;
 
-  public void testConstructor() throws Exception {
+import org.junit.Test;
+
+public class CarrierMovementTest {
+
+  @Test
+  public void testConstructor() {
     try {
       new CarrierMovement(null, null, new Date(), new Date());
       fail("Should not accept null constructor arguments");
@@ -25,7 +27,8 @@ public class CarrierMovementTest extends TestCase {
     new CarrierMovement(STOCKHOLM, HAMBURG, new Date(), new Date());
   }
 
-  public void testSameValueAsEqualsHashCode() throws Exception {
+  @Test
+  public void testSameValueAsEqualsHashCode() {
     CarrierMovement cm1 = new CarrierMovement(STOCKHOLM, HAMBURG, new Date(), new Date());
     CarrierMovement cm2 = new CarrierMovement(STOCKHOLM, HAMBURG, new Date(), new Date());
     CarrierMovement cm3 = new CarrierMovement(HAMBURG, STOCKHOLM, new Date(), new Date());

--- a/src/test/java/se/citerus/dddsample/domain/model/voyage/ScheduleTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/voyage/ScheduleTest.java
@@ -1,26 +1,31 @@
 package se.citerus.dddsample.domain.model.voyage;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class ScheduleTest extends TestCase {
+public class ScheduleTest {
 
-    public void testCarrierMovements() throws Exception {
+    @Test
+    public void testCarrierMovements() {
         //TODO: Test goes here...
     }
 
-    public void testSameValueAs() throws Exception {
+    @Test
+    public void testSameValueAs() {
         //TODO: Test goes here...
     }
 
-    public void testCopy() throws Exception {
+    @Test
+    public void testCopy() {
         //TODO: Test goes here...
     }
 
-    public void testEquals() throws Exception {
+    @Test
+    public void testEquals() {
         //TODO: Test goes here...
     }
 
-    public void testHashCode() throws Exception {
+    @Test
+    public void testHashCode() {
         //TODO: Test goes here...
     }
 

--- a/src/test/java/se/citerus/dddsample/domain/model/voyage/VoyageNumberTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/voyage/VoyageNumberTest.java
@@ -1,30 +1,38 @@
 package se.citerus.dddsample.domain.model.voyage;
 
+import org.junit.Test;
+
 import junit.framework.TestCase;
 
 public class VoyageNumberTest extends TestCase {
 
-    public void testEquals() throws Exception {
+    @Test
+    public void testEquals() {
         //TODO: Test goes here...
     }
 
-    public void testHashCode() throws Exception {
+    @Test
+    public void testHashCode() {
         //TODO: Test goes here...
     }
 
-    public void testSameValueAs() throws Exception {
+    @Test
+    public void testSameValueAs() {
         //TODO: Test goes here...
     }
 
-    public void testCopy() throws Exception {
+    @Test
+    public void testCopy() {
         //TODO: Test goes here...
     }
 
-    public void testToString() throws Exception {
+    @Test
+    public void testToString() {
         //TODO: Test goes here...
     }
 
-    public void testIdString() throws Exception {
+    @Test
+    public void testIdString() {
         //TODO: Test goes here...
     }
 

--- a/src/test/java/se/citerus/dddsample/domain/model/voyage/VoyageTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/model/voyage/VoyageTest.java
@@ -1,38 +1,47 @@
 package se.citerus.dddsample.domain.model.voyage;
 
+import org.junit.Test;
+
 import junit.framework.TestCase;
 
 public class VoyageTest extends TestCase {
 
-    public void testVoyageNumber() throws Exception {
+    @Test
+    public void testVoyageNumber() {
         //TODO: Test goes here...
     }
 
-    public void testSchedule() throws Exception {
+    @Test
+    public void testSchedule() {
         //TODO: Test goes here...
     }
 
-    public void testHashCode() throws Exception {
+    @Test
+    public void testHashCode() {
         //TODO: Test goes here...
     }
 
-    public void testEquals() throws Exception {
+    @Test
+    public void testEquals() {
         //TODO: Test goes here...
     }
 
-    public void testSameIdentityAs() throws Exception {
+    @Test
+    public void testSameIdentityAs() {
         //TODO: Test goes here...
     }
 
-    public void testToString() throws Exception {
+    @Test
+    public void testToString() {
         //TODO: Test goes here...
     }
 
-    public void testAddMovement() throws Exception {
+    @Test
+    public void testAddMovement() {
         //TODO: Test goes here...
     }
 
-    public void testBuild() throws Exception {
+    public void testBuild() {
         //TODO: Test goes here...
     }
 

--- a/src/test/java/se/citerus/dddsample/domain/shared/AndSpecificationTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/shared/AndSpecificationTest.java
@@ -1,12 +1,13 @@
 package se.citerus.dddsample.domain.shared;
 
-import junit.framework.TestCase;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AndSpecificationTest extends TestCase {
+import org.junit.Test;
 
-  public void testAndIsSatisifedBy() throws Exception {
+public class AndSpecificationTest {
+
+  @Test
+  public void testAndIsSatisifedBy() {
     AlwaysTrueSpec trueSpec = new AlwaysTrueSpec();
     AlwaysFalseSpec falseSpec = new AlwaysFalseSpec();
 

--- a/src/test/java/se/citerus/dddsample/domain/shared/NotSpecificationTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/shared/NotSpecificationTest.java
@@ -1,12 +1,13 @@
 package se.citerus.dddsample.domain.shared;
 
-import junit.framework.TestCase;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NotSpecificationTest extends TestCase {
+import org.junit.Test;
 
-  public void testAndIsSatisifedBy() throws Exception {
+public class NotSpecificationTest {
+
+  @Test
+  public void testAndIsSatisifedBy() {
     AlwaysTrueSpec trueSpec = new AlwaysTrueSpec();
     AlwaysFalseSpec falseSpec = new AlwaysFalseSpec();
 

--- a/src/test/java/se/citerus/dddsample/domain/shared/OrSpecificationTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/shared/OrSpecificationTest.java
@@ -1,12 +1,13 @@
 package se.citerus.dddsample.domain.shared;
 
-import junit.framework.TestCase;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OrSpecificationTest extends TestCase {
+import org.junit.Test;
 
-  public void testAndIsSatisifedBy() throws Exception {
+public class OrSpecificationTest {
+
+  @Test
+  public void testAndIsSatisifedBy() {
     AlwaysTrueSpec trueSpec = new AlwaysTrueSpec();
     AlwaysFalseSpec falseSpec = new AlwaysFalseSpec();
 

--- a/src/test/java/se/citerus/dddsample/domain/shared/experimental/ValueObjectSupportTest.java
+++ b/src/test/java/se/citerus/dddsample/domain/shared/experimental/ValueObjectSupportTest.java
@@ -1,12 +1,12 @@
 package se.citerus.dddsample.domain.shared.experimental;
 
-import junit.framework.TestCase;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Test;
 
-public class ValueObjectSupportTest extends TestCase {
+public class ValueObjectSupportTest {
 
+    @Test
     public void testEquals() {
         final AValueObject vo1 = new AValueObject("A");
         final AValueObject vo2 = new AValueObject("A");

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/CargoRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/CargoRepositoryTest.java
@@ -1,5 +1,23 @@
 package se.citerus.dddsample.infrastructure.persistence.hibernate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.LOAD;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.RECEIVE;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HELSINKI;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HONGKONG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.MELBOURNE;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.TOKYO;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM004;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.Before;
@@ -9,12 +27,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.hibernate4.HibernateTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
+
 import se.citerus.dddsample.application.util.SampleDataGenerator;
-import se.citerus.dddsample.domain.model.cargo.*;
+import se.citerus.dddsample.domain.model.cargo.Cargo;
+import se.citerus.dddsample.domain.model.cargo.CargoRepository;
+import se.citerus.dddsample.domain.model.cargo.Itinerary;
+import se.citerus.dddsample.domain.model.cargo.Leg;
+import se.citerus.dddsample.domain.model.cargo.RouteSpecification;
+import se.citerus.dddsample.domain.model.cargo.TrackingId;
 import se.citerus.dddsample.domain.model.handling.HandlingEvent;
 import se.citerus.dddsample.domain.model.handling.HandlingEventRepository;
 import se.citerus.dddsample.domain.model.location.Location;
@@ -24,22 +47,8 @@ import se.citerus.dddsample.domain.model.voyage.Voyage;
 import se.citerus.dddsample.domain.model.voyage.VoyageNumber;
 import se.citerus.dddsample.domain.model.voyage.VoyageRepository;
 
-import javax.sql.DataSource;
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.LOAD;
-import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.RECEIVE;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM004;
-
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 @ContextConfiguration(value = {"/context-infrastructure-persistence.xml"})
-@TransactionConfiguration(transactionManager = "transactionManager")
 @Transactional
 public class CargoRepositoryTest {
 

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/CarrierMovementRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/CarrierMovementRepositoryTest.java
@@ -1,5 +1,9 @@
 package se.citerus.dddsample.infrastructure.persistence.hibernate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.sql.DataSource;
+
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,22 +12,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.hibernate4.HibernateTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
+
 import se.citerus.dddsample.application.util.SampleDataGenerator;
 import se.citerus.dddsample.domain.model.voyage.Voyage;
 import se.citerus.dddsample.domain.model.voyage.VoyageNumber;
 import se.citerus.dddsample.domain.model.voyage.VoyageRepository;
 
-import javax.sql.DataSource;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 @ContextConfiguration(value = {"/context-infrastructure-persistence.xml"})
-@TransactionConfiguration(transactionManager = "transactionManager")
 @Transactional
 public class CarrierMovementRepositoryTest {
 
@@ -48,7 +47,7 @@ public class CarrierMovementRepositoryTest {
     }
 
     @Test
-    public void testFind() throws Exception {
+    public void testFind() {
         Voyage voyage = voyageRepository.find(new VoyageNumber("0101"));
         assertThat(voyage).isNotNull();
         assertThat(voyage.voyageNumber().idString()).isEqualTo("0101");

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/HandlingEventRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/HandlingEventRepositoryTest.java
@@ -1,5 +1,15 @@
 package se.citerus.dddsample.infrastructure.persistence.hibernate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.Before;
@@ -9,10 +19,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.hibernate4.HibernateTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
+
 import se.citerus.dddsample.application.util.SampleDataGenerator;
 import se.citerus.dddsample.domain.model.cargo.Cargo;
 import se.citerus.dddsample.domain.model.cargo.CargoRepository;
@@ -23,18 +33,8 @@ import se.citerus.dddsample.domain.model.location.Location;
 import se.citerus.dddsample.domain.model.location.LocationRepository;
 import se.citerus.dddsample.domain.model.location.UnLocode;
 
-import javax.sql.DataSource;
-import java.lang.reflect.Field;
-import java.sql.Timestamp;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 @ContextConfiguration(value = {"/context-infrastructure-persistence.xml"})
-@TransactionConfiguration(transactionManager = "transactionManager")
 @Transactional
 public class HandlingEventRepositoryTest {
 
@@ -108,7 +108,7 @@ public class HandlingEventRepositoryTest {
     }
 
     @Test
-    public void testFindEventsForCargo() throws Exception {
+    public void testFindEventsForCargo() {
         TrackingId trackingId = new TrackingId("XYZ");
         List<HandlingEvent> handlingEvents = handlingEventRepository.lookupHandlingHistoryOfCargo(trackingId).distinctEventsByCompletionTime();
         assertThat(handlingEvents).hasSize(12);

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/LocationRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/LocationRepositoryTest.java
@@ -1,5 +1,11 @@
 package se.citerus.dddsample.infrastructure.persistence.hibernate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -7,23 +13,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.hibernate4.HibernateTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
+
 import se.citerus.dddsample.application.util.SampleDataGenerator;
 import se.citerus.dddsample.domain.model.location.Location;
 import se.citerus.dddsample.domain.model.location.LocationRepository;
 import se.citerus.dddsample.domain.model.location.UnLocode;
 
-import javax.sql.DataSource;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 @ContextConfiguration(value = {"/context-infrastructure-persistence.xml"})
-@TransactionConfiguration(transactionManager = "transactionManager")
 @Transactional
 public class LocationRepositoryTest {
     @Autowired
@@ -42,7 +42,7 @@ public class LocationRepositoryTest {
     }
 
     @Test
-    public void testFind() throws Exception {
+    public void testFind() {
         final UnLocode melbourne = new UnLocode("AUMEL");
         Location location = locationRepository.find(melbourne);
         assertThat(location).isNotNull();
@@ -52,7 +52,7 @@ public class LocationRepositoryTest {
     }
 
     @Test
-    public void testFindAll() throws Exception {
+    public void testFindAll() {
         List<Location> allLocations = locationRepository.findAll();
 
         assertThat(allLocations).isNotNull();

--- a/src/test/java/se/citerus/dddsample/infrastructure/routing/ExternalRoutingServiceTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/routing/ExternalRoutingServiceTest.java
@@ -1,10 +1,33 @@
 package se.citerus.dddsample.infrastructure.routing;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.GOTHENBURG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HELSINKI;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HONGKONG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.TOKYO;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import com.pathfinder.api.GraphTraversalService;
 import com.pathfinder.internal.GraphDAOStub;
 import com.pathfinder.internal.GraphTraversalServiceImpl;
-import junit.framework.TestCase;
-import se.citerus.dddsample.domain.model.cargo.*;
+
+import se.citerus.dddsample.domain.model.cargo.Cargo;
+import se.citerus.dddsample.domain.model.cargo.Itinerary;
+import se.citerus.dddsample.domain.model.cargo.Leg;
+import se.citerus.dddsample.domain.model.cargo.RouteSpecification;
+import se.citerus.dddsample.domain.model.cargo.TrackingId;
 import se.citerus.dddsample.domain.model.location.Location;
 import se.citerus.dddsample.domain.model.location.LocationRepository;
 import se.citerus.dddsample.domain.model.voyage.SampleVoyages;
@@ -12,20 +35,13 @@ import se.citerus.dddsample.domain.model.voyage.VoyageNumber;
 import se.citerus.dddsample.domain.model.voyage.VoyageRepository;
 import se.citerus.dddsample.infrastructure.persistence.inmemory.LocationRepositoryInMem;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.easymock.EasyMock.*;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-
-public class ExternalRoutingServiceTest extends TestCase {
+public class ExternalRoutingServiceTest {
 
   private ExternalRoutingService externalRoutingService;
   private VoyageRepository voyageRepository;
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() {
     externalRoutingService = new ExternalRoutingService();
     LocationRepository locationRepository = new LocationRepositoryInMem();
     externalRoutingService.setLocationRepository(locationRepository);
@@ -45,7 +61,7 @@ public class ExternalRoutingServiceTest extends TestCase {
   }
 
   // TODO this test belongs in com.pathfinder
-
+  @Test
   public void testCalculatePossibleRoutes() {
     TrackingId trackingId = new TrackingId("ABC");
     RouteSpecification routeSpecification = new RouteSpecification(HONGKONG, HELSINKI, new Date());

--- a/src/test/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/CargoRoutingDTOAssemblerTest.java
+++ b/src/test/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/CargoRoutingDTOAssemblerTest.java
@@ -1,21 +1,30 @@
 package se.citerus.dddsample.interfaces.booking.facade.internal.assembler;
 
-import junit.framework.TestCase;
-import se.citerus.dddsample.domain.model.cargo.*;
-import se.citerus.dddsample.domain.model.location.Location;
-import se.citerus.dddsample.interfaces.booking.facade.dto.CargoRoutingDTO;
-import se.citerus.dddsample.interfaces.booking.facade.dto.LegDTO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.MELBOURNE;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.ROTTERDAM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.SHANGHAI;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
 
 import java.util.Arrays;
 import java.util.Date;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
+import org.junit.Test;
 
-public class CargoRoutingDTOAssemblerTest extends TestCase {
+import se.citerus.dddsample.domain.model.cargo.Cargo;
+import se.citerus.dddsample.domain.model.cargo.Itinerary;
+import se.citerus.dddsample.domain.model.cargo.Leg;
+import se.citerus.dddsample.domain.model.cargo.RouteSpecification;
+import se.citerus.dddsample.domain.model.cargo.TrackingId;
+import se.citerus.dddsample.domain.model.location.Location;
+import se.citerus.dddsample.interfaces.booking.facade.dto.CargoRoutingDTO;
+import se.citerus.dddsample.interfaces.booking.facade.dto.LegDTO;
 
-  public void testToDTO() throws Exception {
+public class CargoRoutingDTOAssemblerTest {
+
+  @Test
+  public void testToDTO() {
     final CargoRoutingDTOAssembler assembler = new CargoRoutingDTOAssembler();
 
     final Location origin = STOCKHOLM;
@@ -46,7 +55,8 @@ public class CargoRoutingDTOAssemblerTest extends TestCase {
     assertThat(legDTO.getTo()).isEqualTo("AUMEL");
   }
 
-  public void testToDTO_NoItinerary() throws Exception {
+  @Test
+  public void testToDTO_NoItinerary() {
     final CargoRoutingDTOAssembler assembler = new CargoRoutingDTOAssembler();
 
     final Cargo cargo = new Cargo(new TrackingId("XYZ"), new RouteSpecification(STOCKHOLM, MELBOURNE, new Date()));

--- a/src/test/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/ItineraryCandidateDTOAssemblerTest.java
+++ b/src/test/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/ItineraryCandidateDTOAssemblerTest.java
@@ -1,6 +1,25 @@
 package se.citerus.dddsample.interfaces.booking.facade.internal.assembler;
 
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.CHICAGO;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HONGKONG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.MELBOURNE;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.ROTTERDAM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.SHANGHAI;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.TOKYO;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Test;
+
 import se.citerus.dddsample.domain.model.cargo.Itinerary;
 import se.citerus.dddsample.domain.model.cargo.Leg;
 import se.citerus.dddsample.domain.model.location.Location;
@@ -11,19 +30,10 @@ import se.citerus.dddsample.infrastructure.persistence.inmemory.VoyageRepository
 import se.citerus.dddsample.interfaces.booking.facade.dto.LegDTO;
 import se.citerus.dddsample.interfaces.booking.facade.dto.RouteCandidateDTO;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+public class ItineraryCandidateDTOAssemblerTest {
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.easymock.EasyMock.*;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
-
-public class ItineraryCandidateDTOAssemblerTest extends TestCase {
-
-  public void testToDTO() throws Exception {
+  @Test
+  public void testToDTO() {
     final ItineraryCandidateDTOAssembler assembler = new ItineraryCandidateDTOAssembler();
 
     final Location origin = STOCKHOLM;
@@ -50,7 +60,8 @@ public class ItineraryCandidateDTOAssemblerTest extends TestCase {
     assertThat(legDTO.getTo()).isEqualTo("AUMEL");
   }
 
-  public void testFromDTO() throws Exception {
+  @Test
+  public void testFromDTO() {
     final ItineraryCandidateDTOAssembler assembler = new ItineraryCandidateDTOAssembler();
 
     final List<LegDTO> legs = new ArrayList<LegDTO>();

--- a/src/test/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/LocationDTOAssemblerTest.java
+++ b/src/test/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/LocationDTOAssemblerTest.java
@@ -1,18 +1,20 @@
 package se.citerus.dddsample.interfaces.booking.facade.internal.assembler;
 
-import junit.framework.TestCase;
-import se.citerus.dddsample.domain.model.location.Location;
-import se.citerus.dddsample.interfaces.booking.facade.dto.LocationDTO;
-
-import java.util.Arrays;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.citerus.dddsample.domain.model.location.SampleLocations.HAMBURG;
 import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
 
-public class LocationDTOAssemblerTest extends TestCase {
+import java.util.Arrays;
+import java.util.List;
 
+import org.junit.Test;
+
+import se.citerus.dddsample.domain.model.location.Location;
+import se.citerus.dddsample.interfaces.booking.facade.dto.LocationDTO;
+
+public class LocationDTOAssemblerTest {
+
+  @Test
   public void testToDTOList() {
     final LocationDTOAssembler assembler = new LocationDTOAssembler();
     final List<Location> locationList = Arrays.asList(STOCKHOLM, HAMBURG);

--- a/src/test/java/se/citerus/dddsample/interfaces/tracking/CargoTrackingControllerTest.java
+++ b/src/test/java/se/citerus/dddsample/interfaces/tracking/CargoTrackingControllerTest.java
@@ -1,10 +1,15 @@
 package se.citerus.dddsample.interfaces.tracking;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -12,16 +17,12 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
 import se.citerus.dddsample.infrastructure.persistence.inmemory.CargoRepositoryInMem;
 import se.citerus.dddsample.infrastructure.persistence.inmemory.HandlingEventRepositoryInMem;
 
-import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-
-
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = CargoTrackingControllerTest.TestConfiguration.class)
 public class CargoTrackingControllerTest {

--- a/src/test/java/se/citerus/dddsample/interfaces/tracking/CargoTrackingViewAdapterTest.java
+++ b/src/test/java/se/citerus/dddsample/interfaces/tracking/CargoTrackingViewAdapterTest.java
@@ -1,22 +1,29 @@
 package se.citerus.dddsample.interfaces.tracking;
 
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HANGZOU;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HELSINKI;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.junit.Test;
 import org.springframework.context.support.StaticApplicationContext;
+
 import se.citerus.dddsample.domain.model.cargo.Cargo;
 import se.citerus.dddsample.domain.model.cargo.RouteSpecification;
 import se.citerus.dddsample.domain.model.cargo.TrackingId;
 import se.citerus.dddsample.domain.model.handling.HandlingEvent;
 import se.citerus.dddsample.domain.model.handling.HandlingHistory;
 
-import java.util.*;
+public class CargoTrackingViewAdapterTest {
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.HANGZOU;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.HELSINKI;
-import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.CM001;
-
-public class CargoTrackingViewAdapterTest extends TestCase {
-
+  @Test
   public void testCreate() {
     Cargo cargo = new Cargo(new TrackingId("XYZ"), new RouteSpecification(HANGZOU, HELSINKI, new Date()));
 

--- a/src/test/java/se/citerus/dddsample/interfaces/tracking/TrackCommandValidatorTest.java
+++ b/src/test/java/se/citerus/dddsample/interfaces/tracking/TrackCommandValidatorTest.java
@@ -1,25 +1,28 @@
 package se.citerus.dddsample.interfaces.tracking;
 
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class TrackCommandValidatorTest extends TestCase {
+public class TrackCommandValidatorTest {
 
   TrackCommandValidator validator;
   TrackCommand command;
   BindingResult errors;
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() {
     validator = new TrackCommandValidator();
     command = new TrackCommand();
     errors = new BeanPropertyBindingResult(command, "command");
   }
 
-  public void testValidateIllegalId() throws Exception {
+  @Test
+  public void testValidateIllegalId() {
     validator.validate(command, errors);
 
     assertThat(errors.getErrorCount()).isEqualTo(1);
@@ -28,8 +31,9 @@ public class TrackCommandValidatorTest extends TestCase {
     assertThat(error.getRejectedValue()).isNull();
     assertThat(error.getCode()).isEqualTo("error.required");
   }
-    
-  public void testValidateSuccess() throws Exception {
+
+  @Test
+  public void testValidateSuccess() {
     command.setTrackingId("non-empty");
     validator.validate(command, errors);
 

--- a/src/test/java/se/citerus/dddsample/scenario/CargoLifecycleScenarioTest.java
+++ b/src/test/java/se/citerus/dddsample/scenario/CargoLifecycleScenarioTest.java
@@ -1,6 +1,38 @@
 package se.citerus.dddsample.scenario;
 
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static se.citerus.dddsample.application.util.DateTestUtil.toDate;
+import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.MISROUTED;
+import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.NOT_ROUTED;
+import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.ROUTED;
+import static se.citerus.dddsample.domain.model.cargo.TransportStatus.CLAIMED;
+import static se.citerus.dddsample.domain.model.cargo.TransportStatus.IN_PORT;
+import static se.citerus.dddsample.domain.model.cargo.TransportStatus.NOT_RECEIVED;
+import static se.citerus.dddsample.domain.model.cargo.TransportStatus.ONBOARD_CARRIER;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.CLAIM;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.LOAD;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.RECEIVE;
+import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.UNLOAD;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.CHICAGO;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HAMBURG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.HONGKONG;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.NEWYORK;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.STOCKHOLM;
+import static se.citerus.dddsample.domain.model.location.SampleLocations.TOKYO;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.v100;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.v200;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.v300;
+import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.v400;
+import static se.citerus.dddsample.domain.model.voyage.Voyage.NONE;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import se.citerus.dddsample.application.ApplicationEvents;
 import se.citerus.dddsample.application.BookingService;
 import se.citerus.dddsample.application.CargoInspectionService;
@@ -8,7 +40,13 @@ import se.citerus.dddsample.application.HandlingEventService;
 import se.citerus.dddsample.application.impl.BookingServiceImpl;
 import se.citerus.dddsample.application.impl.CargoInspectionServiceImpl;
 import se.citerus.dddsample.application.impl.HandlingEventServiceImpl;
-import se.citerus.dddsample.domain.model.cargo.*;
+import se.citerus.dddsample.domain.model.cargo.Cargo;
+import se.citerus.dddsample.domain.model.cargo.CargoRepository;
+import se.citerus.dddsample.domain.model.cargo.HandlingActivity;
+import se.citerus.dddsample.domain.model.cargo.Itinerary;
+import se.citerus.dddsample.domain.model.cargo.Leg;
+import se.citerus.dddsample.domain.model.cargo.RouteSpecification;
+import se.citerus.dddsample.domain.model.cargo.TrackingId;
 import se.citerus.dddsample.domain.model.handling.CannotCreateHandlingEventException;
 import se.citerus.dddsample.domain.model.handling.HandlingEventFactory;
 import se.citerus.dddsample.domain.model.handling.HandlingEventRepository;
@@ -24,20 +62,7 @@ import se.citerus.dddsample.infrastructure.persistence.inmemory.HandlingEventRep
 import se.citerus.dddsample.infrastructure.persistence.inmemory.LocationRepositoryInMem;
 import se.citerus.dddsample.infrastructure.persistence.inmemory.VoyageRepositoryInMem;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static se.citerus.dddsample.application.util.DateTestUtil.toDate;
-import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.*;
-import static se.citerus.dddsample.domain.model.cargo.TransportStatus.*;
-import static se.citerus.dddsample.domain.model.handling.HandlingEvent.Type.*;
-import static se.citerus.dddsample.domain.model.location.SampleLocations.*;
-import static se.citerus.dddsample.domain.model.voyage.SampleVoyages.*;
-import static se.citerus.dddsample.domain.model.voyage.Voyage.NONE;
-
-public class CargoLifecycleScenarioTest extends TestCase {
+public class CargoLifecycleScenarioTest {
 
   /**
    * Repository implementations are part of the infrastructure layer,
@@ -84,6 +109,7 @@ public class CargoLifecycleScenarioTest extends TestCase {
    */
   RoutingService routingService;
 
+  @Test
   public void testCargoFromHongkongToStockholm() throws Exception {
     /* Test setup: A cargo should be shipped from Hongkong to Stockholm,
        and it should arrive in no more than two weeks. */
@@ -296,7 +322,8 @@ public class CargoLifecycleScenarioTest extends TestCase {
     return itineraries.get(0);
   }
 
-  protected void setUp() throws Exception {
+  @Before
+  public void setUp() {
     routingService = new RoutingService() {
       public List<Itinerary> fetchRoutesForSpecification(RouteSpecification routeSpecification) {
         if (routeSpecification.origin().equals(HONGKONG)) {


### PR DESCRIPTION
Prior to this commit the tests had a mixture of JUnit4 and JUnit3 style
of writing. With this commit all tests are using JUnit4 style with
annotations.

With this commit the Spring part has also been polished to use the
updated runner and cleanup the tests to remove the deprecation warnings
due to deprecated annotations.