### PR TITLE
Upgrade spring-boot to version 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.10.RELEASE</version>
+        <version>2.0.1.RELEASE</version>
     </parent>
     <description>This application shows a few key concepts of
         Domain Driven Design implemented in Enterprise Java.
@@ -71,8 +71,8 @@
     </scm>
     <properties>
         <java.version>1.8</java.version>
-        <assertj.version>3.8.0</assertj.version>
-        <hibernate.version>4.3.5.Final</hibernate.version>
+        <!--<assertj.version>3.8.0</assertj.version>-->
+        <!--<hibernate.version>4.3.5.Final</hibernate.version>-->
     </properties>
     <build>
         <plugins>
@@ -102,12 +102,13 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-spring-boot-starter-jaxws</artifactId>
-            <version>3.1.12</version>
+            <version>3.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
+
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
@@ -116,16 +117,16 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>
@@ -143,7 +144,7 @@
         <dependency>
             <groupId>org.apache.xbean</groupId>
             <artifactId>xbean-spring</artifactId>
-            <version>3.4.3</version>
+            <version>4.8</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -159,6 +160,10 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>htmlunit-driver</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -166,15 +166,21 @@
         <plugins>
             <!-- Javadoc -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.0</version>
             </plugin>
             <!-- Source code cross reference -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
+                <version>2.5</version>
             </plugin>
             <!-- Test report -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>2.20.1</version>
             </plugin>
             <!-- Test coverage -->
             <plugin>
@@ -183,11 +189,14 @@
             </plugin>
             <!-- CheckStyle report -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
                 <configuration>
                     <configLocation>src/main/config/checkstyle.xml</configLocation>
                     <!-- Java source code generated from WSDL -->
                     <excludes>**/com/aggregator/**/*</excludes>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/config/checkstyle.xml
+++ b/src/main/config/checkstyle.xml
@@ -18,8 +18,8 @@
  -->
 
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <!--
 
@@ -52,7 +52,9 @@
 
     <!-- Checks that a package.html file exists for each package.     -->
     <!-- See http://checkstyle.sf.net/config_javadoc.html#PackageHtml -->
-    <module name="PackageHtml"/>
+    <module name="JavadocPackage">
+        <property name="allowLegacy" value="true" />
+    </module>
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
@@ -62,6 +64,15 @@
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
     <module name="Translation"/>
 
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="FileLength"/>
+    <module name="FileTabCharacter"/>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>
 
     <module name="TreeWalker">
 
@@ -112,14 +123,13 @@
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
         <module name="AvoidStarImport"/>
-        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="sun.*, org.apache.commons.logging"/>
+        </module>
+
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
 
-
-        <!-- Checks for Size Violations.                    -->
-        <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="FileLength"/>
 
         <module name="LineLength">
          <property name="max" value="120"/>
@@ -146,7 +156,7 @@
         
         <module name="WhitespaceAfter">
           <!-- Default tokens and additional GENERIC_END -->
-          <property name="tokens" value="COMMA, SEMI, TYPECAST, GENERIC_END"/>
+          <property name="tokens" value="COMMA, SEMI, TYPECAST"/>
         </module>
         
         <module name="WhitespaceAround">
@@ -165,7 +175,6 @@
         <module name="OperatorWrap"/>
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
-        <module name="TabCharacter"/>
 
 
         <!-- Modifier Checks                                    -->
@@ -185,14 +194,12 @@
 
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
-        <module name="DoubleCheckedLocking"/>    <!-- MY FAVOURITE -->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <module name="MagicNumber"/>
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 
@@ -209,10 +216,7 @@
         <!-- See http://checkstyle.sf.net/config_misc.html -->
         <module name="ArrayTypeStyle"/>
         <module name="FinalParameters"/>
-        <module name="GenericIllegalRegexp">
-            <property name="format" value="\s+$"/>
-            <property name="message" value="Line has trailing spaces."/>
-        </module>
+
         <module name="TodoComment"/>
         <module name="UpperEll"/>
 

--- a/src/main/java/com/pathfinder/api/GraphTraversalService.java
+++ b/src/main/java/com/pathfinder/api/GraphTraversalService.java
@@ -1,7 +1,6 @@
 package com.pathfinder.api;
 
 import java.rmi.Remote;
-import java.rmi.RemoteException;
 import java.util.List;
 import java.util.Properties;
 
@@ -17,7 +16,7 @@ public interface GraphTraversalService extends Remote {
    * @param destination destination point
    * @param limitations restrictions on the path selection, as key-value according to some API specification
    * @return A list of transit paths
-   * @throws RemoteException RMI problem
+   * @throws java.rmi.RemoteException RMI problem
    */
   List<TransitPath> findShortestPath(String origin,
                                      String destination,

--- a/src/main/java/se/citerus/dddsample/domain/model/cargo/Cargo.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/cargo/Cargo.java
@@ -1,7 +1,7 @@
 package se.citerus.dddsample.domain.model.cargo;
 
 import org.apache.commons.lang.Validate;
-import se.citerus.dddsample.domain.model.handling.HandlingEvent;
+
 import se.citerus.dddsample.domain.model.handling.HandlingHistory;
 import se.citerus.dddsample.domain.model.location.Location;
 import se.citerus.dddsample.domain.shared.DomainObjectUtils;
@@ -140,7 +140,7 @@ public class Cargo implements Entity<Cargo> {
    * {@link RouteSpecification} and {@link Itinerary} are both inside the Cargo
    * aggregate, so changes to them cause the status to be updated <b>synchronously</b>,
    * but changes to the delivery history (when a cargo is handled) cause the status update
-   * to happen <b>asynchronously</b> since {@link HandlingEvent} is in a different aggregate.
+   * to happen <b>asynchronously</b> since {@link se.citerus.dddsample.domain.model.handling.HandlingEvent} is in a different aggregate.
    *
    * @param handlingHistory handling history
    */

--- a/src/main/java/se/citerus/dddsample/domain/model/cargo/CargoRepository.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/cargo/CargoRepository.java
@@ -1,7 +1,5 @@
 package se.citerus.dddsample.domain.model.cargo;
 
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 
 public interface CargoRepository {

--- a/src/main/java/se/citerus/dddsample/interfaces/booking/facade/BookingServiceFacade.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/facade/BookingServiceFacade.java
@@ -1,13 +1,12 @@
 package se.citerus.dddsample.interfaces.booking.facade;
 
-import se.citerus.dddsample.interfaces.booking.facade.dto.CargoRoutingDTO;
-import se.citerus.dddsample.interfaces.booking.facade.dto.LocationDTO;
-import se.citerus.dddsample.interfaces.booking.facade.dto.RouteCandidateDTO;
-
-import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.util.Date;
 import java.util.List;
+
+import se.citerus.dddsample.interfaces.booking.facade.dto.CargoRoutingDTO;
+import se.citerus.dddsample.interfaces.booking.facade.dto.LocationDTO;
+import se.citerus.dddsample.interfaces.booking.facade.dto.RouteCandidateDTO;
 
 /**
  * This facade shields the domain layer - model, services, repositories -

--- a/src/main/java/se/citerus/dddsample/interfaces/booking/facade/internal/BookingServiceFacadeImpl.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/facade/internal/BookingServiceFacadeImpl.java
@@ -1,6 +1,5 @@
 package se.citerus.dddsample.interfaces.booking.facade.internal;
 
-import org.apache.log4j.Logger;
 import se.citerus.dddsample.application.BookingService;
 import se.citerus.dddsample.domain.model.cargo.Cargo;
 import se.citerus.dddsample.domain.model.cargo.CargoRepository;
@@ -23,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This implementation has additional support from the infrastructure, for exposing as an RMI
@@ -36,7 +37,6 @@ public class BookingServiceFacadeImpl implements BookingServiceFacade {
   private LocationRepository locationRepository;
   private CargoRepository cargoRepository;
   private VoyageRepository voyageRepository;
-  private final Logger logger = Logger.getLogger(BookingServiceFacadeImpl.class);
 
   @Override
   public List<LocationDTO> listShippingLocations() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
-server.contextPath=/dddsample
+server.servlet.context-path=/dddsample
 cxf.path=/ws
 
-logging.level.org.hibernate.SQL=debug
-logging.level.org.hibernate.hbm2ddl=debug
+logging.level.org.hibernate.SQL=info
 logging.level.net.sf.ehcache.config.ConfigurationFactory=error

--- a/src/main/resources/context-infrastructure-messaging.xml
+++ b/src/main/resources/context-infrastructure-messaging.xml
@@ -5,8 +5,8 @@
        xmlns:amq="http://activemq.apache.org/schema/core"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-2.5.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms.xsd
         http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
 
   <!-- JMS messaging -->

--- a/src/main/resources/context-infrastructure-persistence.xml
+++ b/src/main/resources/context-infrastructure-persistence.xml
@@ -2,32 +2,31 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
   <!-- Persistence - database, Hibernate, transactions, repository implementations -->
 
-  <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-    <property name="location" value="classpath:/jdbc.properties"/>
-  </bean>
+  <context:property-placeholder location="classpath:/jdbc.properties" />
 
-  <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
-    <property name="url" value="${hibernate.connection.url}"/>
+  <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource">
+    <property name="jdbcUrl" value="${hibernate.connection.url}"/>
     <property name="driverClassName" value="${hibernate.connection.driver_class}"/>
     <property name="username" value="${hibernate.connection.username}"/>
     <property name="password" value="${hibernate.connection.password}"/>
-    <property name="initialSize" value="4"/>
-    <property name="defaultAutoCommit" value="false"/>
+    <property name="minimumIdle" value="4"/>
+    <property name="autoCommit" value="false"/>
   </bean>
 
-  <bean id="sessionFactory" class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
     <property name="dataSource" ref="dataSource"/>
     <property name="configLocation" value="classpath:/hibernate.cfg.xml"/>
   </bean>
 
-  <bean id="transactionManager" class="org.springframework.orm.hibernate4.HibernateTransactionManager">
+  <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
     <property name="sessionFactory" ref="sessionFactory"/>
   </bean>
 

--- a/src/main/resources/context-interfaces.xml
+++ b/src/main/resources/context-interfaces.xml
@@ -8,11 +8,9 @@
        xsi:schemaLocation="http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd
                            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-                           http://www.springframework.org/schema/mvc
-                           http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+                           http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
     <import resource="classpath:META-INF/cxf/cxf.xml"/>
-
 
     <!-- Handling report web service -->
 
@@ -21,7 +19,6 @@
     <bean id="handlingReportService" class="se.citerus.dddsample.interfaces.handling.ws.HandlingReportServiceImpl">
         <property name="applicationEvents" ref="applicationEvents"/>
     </bean>
-
 
     <!-- File upload directory scanner -->
 
@@ -70,7 +67,7 @@
     </bean>
 
     <mvc:interceptors>
-        <bean id="openSessionInViewInterceptor" class="org.springframework.orm.hibernate4.support.OpenSessionInViewInterceptor">
+        <bean id="openSessionInViewInterceptor" class="org.springframework.orm.hibernate5.support.OpenSessionInViewInterceptor">
             <property name="sessionFactory" ref="sessionFactory"/>
         </bean>
     </mvc:interceptors>

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -8,8 +8,6 @@
 
   <session-factory>
     <!-- Properties defined here are shared between test and production -->
-    <property name="cache.provider_class">org.hibernate.cache.NoCacheProvider</property>
-    
     <mapping resource="se/citerus/dddsample/infrastructure/persistence/hibernate/Cargo.hbm.xml" />
     <mapping resource="se/citerus/dddsample/infrastructure/persistence/hibernate/Voyage.hbm.xml" />
     <mapping resource="se/citerus/dddsample/infrastructure/persistence/hibernate/Leg.hbm.xml" />

--- a/src/test/java/se/citerus/dddsample/application/BookingServiceTest.java
+++ b/src/test/java/se/citerus/dddsample/application/BookingServiceTest.java
@@ -1,8 +1,9 @@
 package se.citerus.dddsample.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/se/citerus/dddsample/application/HandlingEventServiceTest.java
+++ b/src/test/java/se/citerus/dddsample/application/HandlingEventServiceTest.java
@@ -1,6 +1,6 @@
 package se.citerus.dddsample.application;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/CargoRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/CargoRepositoryTest.java
@@ -25,9 +25,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.orm.hibernate4.HibernateTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -71,7 +71,7 @@ public class CargoRepositoryTest {
     private DataSource dataSource;
 
     @Autowired
-    private HibernateTransactionManager transactionManager;
+    private PlatformTransactionManager transactionManager;
 
     private JdbcTemplate jdbcTemplate;
 

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/CarrierMovementRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/CarrierMovementRepositoryTest.java
@@ -10,9 +10,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.orm.hibernate4.HibernateTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -36,7 +36,7 @@ public class CarrierMovementRepositoryTest {
     private DataSource dataSource;
 
     @Autowired
-    private HibernateTransactionManager transactionManager;
+    private PlatformTransactionManager transactionManager;
 
     private JdbcTemplate jdbcTemplate;
 

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/HandlingEventRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/HandlingEventRepositoryTest.java
@@ -17,9 +17,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.orm.hibernate4.HibernateTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -54,7 +54,7 @@ public class HandlingEventRepositoryTest {
     private DataSource dataSource;
 
     @Autowired
-    private HibernateTransactionManager transactionManager;
+    private PlatformTransactionManager transactionManager;
 
     private JdbcTemplate jdbcTemplate;
 

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/LocationRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/hibernate/LocationRepositoryTest.java
@@ -11,9 +11,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.orm.hibernate4.HibernateTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -33,7 +33,7 @@ public class LocationRepositoryTest {
     private DataSource dataSource;
 
     @Autowired
-    private HibernateTransactionManager transactionManager;
+    private PlatformTransactionManager transactionManager;
 
     @Before
     public void setup() {

--- a/src/test/java/se/citerus/dddsample/infrastructure/routing/ExternalRoutingServiceTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/routing/ExternalRoutingServiceTest.java
@@ -18,7 +18,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static se.citerus.dddsample.domain.model.location.SampleLocations.*;


### PR DESCRIPTION
This commit upgrades the Spring Boot version to the
2.0.1.RELEASE including all the updates with the
referenced libraries. Like Hibernate 5 and a newer
connection pool.

As Spring Boot 2 doesn't support log4j (the 1.x
version) anymore we replaced logging (where needed)
with the SLF4J API.