### PR TITLE
spring-boot-starter-parent:1.5.13.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.10.RELEASE</version>
+        <version>1.5.13.RELEASE</version>
     </parent>
     <description>This application shows a few key concepts of
         Domain Driven Design implemented in Enterprise Java.


### PR DESCRIPTION
Updates the parent pom to match the May 2018 release.