### PR TITLE
Move date formatting from templates to backend

### DIFF
--- a/src/main/java/se/citerus/dddsample/interfaces/booking/facade/dto/CargoRoutingDTO.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/facade/dto/CargoRoutingDTO.java
@@ -14,7 +14,7 @@ public final class CargoRoutingDTO implements Serializable {
   private final String trackingId;
   private final String origin;
   private final String finalDestination;
-  private final Date arrivalDeadline;
+  private final String arrivalDeadline;
   private final boolean misrouted;
   private final List<LegDTO> legs;
 
@@ -27,7 +27,7 @@ public final class CargoRoutingDTO implements Serializable {
    * @param arrivalDeadline
    * @param misrouted
    */
-  public CargoRoutingDTO(String trackingId, String origin, String finalDestination, Date arrivalDeadline, boolean misrouted) {
+  public CargoRoutingDTO(String trackingId, String origin, String finalDestination, String arrivalDeadline, boolean misrouted) {
     this.trackingId = trackingId;
     this.origin = origin;
     this.finalDestination = finalDestination;
@@ -48,7 +48,7 @@ public final class CargoRoutingDTO implements Serializable {
     return finalDestination;
   }
 
-  public void addLeg(String voyageNumber, String from, String to, Date loadTime, Date unloadTime) {
+  public void addLeg(String voyageNumber, String from, String to, String loadTime, String unloadTime) {
     legs.add(new LegDTO(voyageNumber, from, to, loadTime, unloadTime));
   }
 
@@ -67,7 +67,7 @@ public final class CargoRoutingDTO implements Serializable {
     return !legs.isEmpty();
   }
 
-  public Date getArrivalDeadline() {
+  public String getArrivalDeadline() {
     return arrivalDeadline;
   }
 

--- a/src/main/java/se/citerus/dddsample/interfaces/booking/facade/dto/LegDTO.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/facade/dto/LegDTO.java
@@ -11,8 +11,8 @@ public final class LegDTO implements Serializable {
   private final String voyageNumber;
   private final String from;
   private final String to;
-  private final Date loadTime;
-  private final Date unloadTime;
+  private final String loadTime;
+  private final String unloadTime;
 
   /**
    * Constructor.
@@ -23,7 +23,7 @@ public final class LegDTO implements Serializable {
    * @param loadTime
    * @param unloadTime
    */
-  public LegDTO(final String voyageNumber, final String from, final String to, Date loadTime, Date unloadTime) {
+  public LegDTO(final String voyageNumber, final String from, final String to, String loadTime, String unloadTime) {
     this.voyageNumber = voyageNumber;
     this.from = from;
     this.to = to;
@@ -43,11 +43,11 @@ public final class LegDTO implements Serializable {
     return to;
   }
 
-  public Date getLoadTime() {
+  public String getLoadTime() {
     return loadTime;
   }
 
-  public Date getUnloadTime() {
+  public String getUnloadTime() {
     return unloadTime;
   }
   

--- a/src/main/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/AssemblerUtils.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/AssemblerUtils.java
@@ -1,0 +1,27 @@
+package se.citerus.dddsample.interfaces.booking.facade.internal.assembler;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class AssemblerUtils {
+    private static final DateFormat formatter = new SimpleDateFormat("dd/MM/yyyy");
+    private static final DateFormat longFormatter = new SimpleDateFormat("yyyy-MM-dd hh:mm");
+
+    public static String toDTODate(Date date) {
+        return formatter.format(date);
+    }
+
+    public static String toDTOLongDate(Date date) {
+        return longFormatter.format(date);
+    }
+
+    public static Date fromDTODate(String date) {
+        try {
+            return formatter.parse(date);
+        } catch (ParseException e) {
+            throw new RuntimeException(String.format("Error formatting date '%s' with format 'dd/MM/yyyy'", date), e);
+        }
+    }
+}

--- a/src/main/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/CargoRoutingDTOAssembler.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/CargoRoutingDTOAssembler.java
@@ -5,6 +5,8 @@ import se.citerus.dddsample.domain.model.cargo.Leg;
 import se.citerus.dddsample.domain.model.cargo.RoutingStatus;
 import se.citerus.dddsample.interfaces.booking.facade.dto.CargoRoutingDTO;
 
+import static se.citerus.dddsample.interfaces.booking.facade.internal.assembler.AssemblerUtils.toDTODate;
+
 /**
  * Assembler class for the CargoRoutingDTO.
  */
@@ -15,20 +17,20 @@ public class CargoRoutingDTOAssembler {
    * @param cargo cargo
    * @return A cargo routing DTO
    */
-  public CargoRoutingDTO toDTO(final Cargo cargo) {
+  public static CargoRoutingDTO toDTO(final Cargo cargo) {
     final CargoRoutingDTO dto = new CargoRoutingDTO(
       cargo.trackingId().idString(),
       cargo.origin().unLocode().idString(),
       cargo.routeSpecification().destination().unLocode().idString(),
-      cargo.routeSpecification().arrivalDeadline(),
+      toDTODate(cargo.routeSpecification().arrivalDeadline()),
       cargo.delivery().routingStatus().sameValueAs(RoutingStatus.MISROUTED));
     for (Leg leg : cargo.itinerary().legs()) {
       dto.addLeg(
         leg.voyage().voyageNumber().idString(),
         leg.loadLocation().unLocode().idString(),
         leg.unloadLocation().unLocode().idString(),
-        leg.loadTime(),
-        leg.unloadTime());
+        toDTODate(leg.loadTime()),
+        toDTODate(leg.unloadTime()));
     }
     return dto;
   }

--- a/src/main/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/LocationDTOAssembler.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/facade/internal/assembler/LocationDTOAssembler.java
@@ -3,20 +3,18 @@ package se.citerus.dddsample.interfaces.booking.facade.internal.assembler;
 import se.citerus.dddsample.domain.model.location.Location;
 import se.citerus.dddsample.interfaces.booking.facade.dto.LocationDTO;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class LocationDTOAssembler {
 
-  public LocationDTO toDTO(Location location) {
+  public static LocationDTO toDTO(Location location) {
     return new LocationDTO(location.unLocode().idString(), location.name());
   }
 
-  public List<LocationDTO> toDTOList(List<Location> allLocations) {
-    final List<LocationDTO> dtoList = new ArrayList<LocationDTO>(allLocations.size());
-    for (Location location : allLocations) {
-      dtoList.add(toDTO(location));
-    }
-    return dtoList;
+  public static List<LocationDTO> toDTOList(List<Location> allLocations) {
+    return allLocations.stream()
+            .map(LocationDTOAssembler::toDTO)
+            .collect(Collectors.toList());
   }
 }

--- a/src/main/java/se/citerus/dddsample/interfaces/booking/web/CargoAdminController.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/web/CargoAdminController.java
@@ -20,6 +20,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import static se.citerus.dddsample.interfaces.booking.facade.internal.assembler.AssemblerUtils.toDTODate;
+
 /**
  * Handles cargo booking and routing. Operates against a dedicated remoting service facade,
  * and could easily be rewritten as a thick Swing client. Completely separated from the domain layer,
@@ -109,8 +111,8 @@ public final class CargoAdminController {
                             leg.getVoyageNumber(),
                             leg.getFromUnLocode(),
                             leg.getToUnLocode(),
-                            leg.getFromDate(),
-                            leg.getToDate())
+                            toDTODate(leg.getFromDate()),
+                            toDTODate(leg.getToDate()))
             );
         }
 

--- a/src/main/resources/templates/admin/registrationForm.html
+++ b/src/main/resources/templates/admin/registrationForm.html
@@ -40,7 +40,7 @@
             <tr>
                 <td>Arrival deadline:</td>
                 <td>
-                    <input name="arrivalDeadline" type="text" size="10" id="arrivalDeadline" th:value="${#dates.format(#dates.createNow(),'dd/MM/yyyy')}"/>
+                    <input name="arrivalDeadline" type="text" size="10" id="arrivalDeadline"/>
                     <p class="glyphicon glyphicon-calendar"></p>
                 </td>
             </tr>
@@ -60,9 +60,10 @@
 <script th:src="@{/js/bootstrap-datepicker.js}"></script>
 <script type="text/javascript">
     $(document).ready(function () {
+        var today = new Date();
         $('#arrivalDeadline').datepicker({
             format: "dd/mm/yyyy"
-        });
+        }).val(today.getDate() + "/" + (today.getMonth() + 1) + "/" + today.getFullYear());
     });
 </script>
 </body>

--- a/src/main/resources/templates/admin/selectItinerary.html
+++ b/src/main/resources/templates/admin/selectItinerary.html
@@ -44,15 +44,15 @@
                 <input type="hidden" th:name="|legs[${legStatus.index}].toUnLocode|" th:value="${leg.to}"/>
 
                 <input type="hidden" th:name="|legs[${legStatus.index}].fromDate|"
-                       th:value="${#dates.format(leg.loadTime,'yyyy-MM-dd hh:mm')}"/>
+                       th:value="${leg.loadTime}"/>
                 <input type="hidden" th:name="|legs[${legStatus.index}].toDate|"
-                       th:value="${#dates.format(leg.unloadTime,'yyyy-MM-dd hh:mm')}"/>
+                       th:value="${leg.unloadTime}"/>
                 <tr>
                     <td th:text="${leg.voyageNumber}"></td>
                     <td th:text="${leg.from}"></td>
-                    <td th:text="${#dates.format(leg.loadTime,'yyyy-MM-dd hh:mm')}"/>
+                    <td th:text="${leg.loadTime}"/>
                     <td th:text="${leg.to}"></td>
-                    <td th:text="${#dates.format(leg.unloadTime,'yyyy-MM-dd hh:mm')}"/>
+                    <td th:text="${leg.unloadTime}"/>
                 </tr>
             </th:block>
             </tbody>

--- a/src/main/resources/templates/admin/show.html
+++ b/src/main/resources/templates/admin/show.html
@@ -30,7 +30,7 @@
         </tr>
         <tr>
             <td>Arrival deadline</td>
-            <td th:text="${#dates.format(cargo.arrivalDeadline,'dd/MM/yyyy')}"/>
+            <td th:text="${cargo.arrivalDeadline}"/>
         </tr>
         </tbody>
     </table>
@@ -53,9 +53,9 @@
             <tr th:each="leg : ${cargo.legs}">
                 <td th:text="${leg.voyageNumber}"></td>
                 <td th:text="${leg.from}"></td>
-                <td th:text="${#dates.format(leg.loadTime,'dd/MM/yyyy')}"/>
+                <td th:text="${leg.loadTime}"></td>
                 <td th:text="${leg.to}"></td>
-                <td th:text="${#dates.format(leg.unloadTime,'dd/MM/yyyy')}"/>
+                <td th:text="${leg.unloadTime}"></td>
             </tr>
             </tbody>
         </table>


### PR DESCRIPTION
### Why
We currently have logic in the Thymeleaf templates for formatting java.util.Date objects to strings. This makes the templates more complex and requires us to write acceptance-tests using WebDriver to verify the validity of the formatted dates.

### What
This PR moves the formatting of the dates into the DTO assembler-classes in order to simplify the templates and allow us to verify the date formatting using simple unit tests.

(this PR was split out from #59)