### PR TITLE
Replace setter-based injection for ExternalRoutingService

### DIFF
--- a/src/main/java/se/citerus/dddsample/config/DDDSampleApplicationContext.java
+++ b/src/main/java/se/citerus/dddsample/config/DDDSampleApplicationContext.java
@@ -83,11 +83,7 @@ public class DDDSampleApplicationContext {
 
     @Bean
     public RoutingService routingService() {
-        ExternalRoutingService routingService = new ExternalRoutingService();
-        routingService.setGraphTraversalService(graphTraversalService);
-        routingService.setLocationRepository(locationRepository);
-        routingService.setVoyageRepository(voyageRepository);
-        return routingService;
+        return new ExternalRoutingService(graphTraversalService, locationRepository, voyageRepository);
     }
 
     @Bean

--- a/src/main/java/se/citerus/dddsample/infrastructure/routing/ExternalRoutingService.java
+++ b/src/main/java/se/citerus/dddsample/infrastructure/routing/ExternalRoutingService.java
@@ -26,11 +26,17 @@ import java.util.Properties;
  *
  */
 public class ExternalRoutingService implements RoutingService {
-
-  private GraphTraversalService graphTraversalService;
-  private LocationRepository locationRepository;
-  private VoyageRepository voyageRepository;
   private static final Log log = LogFactory.getLog(ExternalRoutingService.class);
+
+  private final GraphTraversalService graphTraversalService;
+  private final LocationRepository locationRepository;
+  private final VoyageRepository voyageRepository;
+
+  public ExternalRoutingService(GraphTraversalService graphTraversalService, LocationRepository locationRepository, VoyageRepository voyageRepository) {
+    this.graphTraversalService = graphTraversalService;
+    this.locationRepository = locationRepository;
+    this.voyageRepository = voyageRepository;
+  }
 
   public List<Itinerary> fetchRoutesForSpecification(RouteSpecification routeSpecification) {
     /*
@@ -83,17 +89,4 @@ public class ExternalRoutingService implements RoutingService {
       edge.getFromDate(), edge.getToDate()
     );
   }
-
-  public void setGraphTraversalService(GraphTraversalService graphTraversalService) {
-    this.graphTraversalService = graphTraversalService;
-  }
-
-  public void setLocationRepository(LocationRepository locationRepository) {
-    this.locationRepository = locationRepository;
-  }
-
-  public void setVoyageRepository(VoyageRepository voyageRepository) {
-    this.voyageRepository = voyageRepository;
-  }
-  
 }

--- a/src/test/java/se/citerus/dddsample/infrastructure/routing/ExternalRoutingServiceTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/routing/ExternalRoutingServiceTest.java
@@ -30,13 +30,8 @@ public class ExternalRoutingServiceTest {
 
   @Before
   public void setUp() {
-    externalRoutingService = new ExternalRoutingService();
     LocationRepository locationRepository = new LocationRepositoryInMem();
-    externalRoutingService.setLocationRepository(locationRepository);
-
     voyageRepository = mock(VoyageRepository.class);
-    externalRoutingService.setVoyageRepository(voyageRepository);
-
     GraphTraversalService graphTraversalService = new GraphTraversalServiceImpl(new GraphDAOStub() {
       public List<String> listLocations() {
         return Arrays.asList(TOKYO.unLocode().idString(), STOCKHOLM.unLocode().idString(), GOTHENBURG.unLocode().idString());
@@ -45,7 +40,7 @@ public class ExternalRoutingServiceTest {
       public void storeCarrierMovementId(String cmId, String from, String to) {
       }
     });
-    externalRoutingService.setGraphTraversalService(graphTraversalService);
+    externalRoutingService = new ExternalRoutingService(graphTraversalService, locationRepository, voyageRepository);
   }
 
   // TODO this test belongs in com.pathfinder
@@ -78,5 +73,4 @@ public class ExternalRoutingServiceTest {
       }
     }
   }
-
 }


### PR DESCRIPTION
### Why
The ExternalRoutingService uses an old style of dependency injection (setter-based DI) that is no longer recommended for use by the Spring developers.

### What
Replaces the setter-based DI with constructor-based DI.

(This PR was split out from #59)