### PR TITLE
Bugfix: Add missing registration of MessageConsumers to JMS queues.

### DIFF
--- a/src/test/resources/sampleSoapBody.xml
+++ b/src/test/resources/sampleSoapBody.xml
@@ -6,11 +6,11 @@
             <arg0>
                 <completionTime>2022-01-01T00:00:00</completionTime>
                 <!--1 or more repetitions:-->
-                <trackingIds>2</trackingIds>
+                <trackingIds>ABC123</trackingIds>
                 <type>LOAD</type>
-                <unLocode>AA234</unLocode>
+                <unLocode>SESTO</unLocode>
                 <!--Optional:-->
-                <voyageNumber>5</voyageNumber>
+                <voyageNumber>0100S</voyageNumber>
             </arg0>
         </ws:submitReport>
     </soapenv:Body>


### PR DESCRIPTION
### Why
The recent refactoring of the messaging package (converting it from XML-based bean definitions to POJOs) accidentally left out the part where the message consumers are registered on JMS queues. Since leaving this out does not cause any errors during startup and since there are no tests that test the JMS integration, this bug was undetected until now. 

### What
Adds registration of message consumers to the JMS queues converted from the old bean XML-configuration. Also updates the example SOAP message with values that I used to test this locally instead of it's previous invalid values.

Let me know if you want me to add some automated integration tests to verify this as well. 