### PR TITLE
Maven Surefire Plugin configuration to resolve module access issues in tests for JDK 9 and newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,14 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
Maven Surefire Plugin configuration to resolve module access issues in tests for JDK 9 and newer