### PR TITLE
Replace ObjectUtils.defaultIfNull with Objects.requireNonNullElse

### DIFF
--- a/src/main/java/se/citerus/dddsample/domain/model/cargo/Cargo.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/cargo/Cargo.java
@@ -5,6 +5,7 @@ import se.citerus.dddsample.domain.model.handling.HandlingHistory;
 import se.citerus.dddsample.domain.model.location.Location;
 import se.citerus.dddsample.domain.shared.Entity;
 
+import java.util.Objects;
 import javax.persistence.*;
 import java.util.List;
 

--- a/src/main/java/se/citerus/dddsample/domain/model/cargo/Delivery.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/cargo/Delivery.java
@@ -13,6 +13,10 @@ import se.citerus.dddsample.domain.shared.ValueObject;
 import javax.persistence.*;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.Objects;
+
+import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.*;
+import static se.citerus.dddsample.domain.model.cargo.TransportStatus.*;
 
 import static se.citerus.dddsample.domain.model.cargo.RoutingStatus.*;
 import static se.citerus.dddsample.domain.model.cargo.TransportStatus.*;
@@ -128,14 +132,14 @@ public class Delivery implements ValueObject<Delivery> {
    * @return Last known location of the cargo, or Location.UNKNOWN if the delivery history is empty.
    */
   public Location lastKnownLocation() {
-      return ObjectUtils.defaultIfNull(lastKnownLocation, Location.UNKNOWN);
+      return Objects.requireNonNullElse(lastKnownLocation, Location.UNKNOWN);
   }
 
   /**
    * @return Current voyage.
    */
   public Voyage currentVoyage() {
-      return ObjectUtils.defaultIfNull(currentVoyage, Voyage.NONE);
+      return Objects.requireNonNullElse(currentVoyage, Voyage.NONE);
   }
 
   /**

--- a/src/main/java/se/citerus/dddsample/domain/model/handling/HandlingEvent.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/handling/HandlingEvent.java
@@ -3,7 +3,6 @@ package se.citerus.dddsample.domain.model.handling;
 import org.apache.commons.lang.Validate;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang3.ObjectUtils;
 import se.citerus.dddsample.domain.model.cargo.Cargo;
 import se.citerus.dddsample.domain.model.location.Location;
 import se.citerus.dddsample.domain.model.voyage.Voyage;
@@ -12,6 +11,7 @@ import se.citerus.dddsample.domain.shared.ValueObject;
 
 import javax.persistence.*;
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * A HandlingEvent is used to register the event when, for instance,
@@ -97,7 +97,7 @@ public final class HandlingEvent implements DomainEvent<HandlingEvent> {
 
     @Override
     public boolean sameValueAs(Type other) {
-      return other != null && this.equals(other);
+      return this.equals(other);
     }
 
   }
@@ -170,7 +170,7 @@ public final class HandlingEvent implements DomainEvent<HandlingEvent> {
   }
 
   public Voyage voyage() {
-    return ObjectUtils.defaultIfNull(this.voyage, Voyage.NONE);
+    return Objects.requireNonNullElse(this.voyage, Voyage.NONE);
   }
 
   public Date completionTime() {


### PR DESCRIPTION
### Why
The current codebase uses a third-party library (Apache Commons) to provide the `ObjectUtils.defaultIfNull` method for providing a default value in case of a null reference. This was the standard practice before Java 11+, but an equivalent method has now been introduced to the standard library in the form of `Objects.requireNonNullElse`. This means we can work towards reducing the amount of third-party dependencies, which improves maintainability.

### What
Replaces all occurrences of `ObjectUtils.defaultIfNull` with `Objects.requireNonNullElse`.
