### PR TITLE
Configure Dependabot to automatically open PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Stockholm"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
       time: "08:00"
       timezone: "Europe/Stockholm"
     labels: ["dependencies"]
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Adds a config file to allow Dependabot to automatically open PRs (but not merge them) updating Maven dependencies to resolve known security vulnerabilities.