### PR TITLE
Add "contents: write" permission to CI workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,5 +1,8 @@
 name: Java CI with Maven
 
+permissions:
+  contents: write
+
 on:
   pull_request:
     branches: [ "*" ]


### PR DESCRIPTION
Add contents: write permission to Github Actions workflow to fix 403 error on workflow runs by external contributors.