### PR TITLE
Make dependency analysis submission step optional

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,3 +29,4 @@ jobs:
       # Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph
         uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+        continue-on-error: true # optional as this step consistently fails for forked repos by design


### PR DESCRIPTION
Given the discovery that the dependency analysis submission step is seemingly failing by design for forked repos (see [this thread](https://github.com/actions/first-interaction/issues/10)), this PR makes it optional by adding the continue-on-error attribute.