### PR TITLE
Increase dependabot open PR limit to 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3


### PR DESCRIPTION
### Why <!-- Briefly describe why these changes are needed -->
A single failing (but important) dependabot-made PR is currently failing, but we don't want to remove it. Due to the 1 PR limit, Dependabot can't make new PRs, which means we can't see if other dependencies need upgrades.

### What <!-- Briefly describe how these changes solve the problem -->
Increases open PR limit to 3 in order to be able to keep the failing PR but still get other new PRs.