### PR TITLE
Fix Instant parsing issue

### DIFF
--- a/src/main/java/se/citerus/dddsample/interfaces/booking/web/RouteAssignmentCommand.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/web/RouteAssignmentCommand.java
@@ -60,16 +60,16 @@ public class RouteAssignmentCommand {
       return fromDate;
     }
 
-    public void setFromDate(Instant fromDate) {
-      this.fromDate = fromDate;
+    public void setFromDate(String fromDate) {
+      this.fromDate = Instant.parse(fromDate);
     }
 
     public Instant getToDate() {
       return toDate;
     }
 
-    public void setToDate(Instant toDate) {
-      this.toDate = toDate;
+    public void setToDate(String toDate) {
+      this.toDate = Instant.parse(toDate);
     }
   }
 }

--- a/src/main/resources/templates/admin/selectItinerary.html
+++ b/src/main/resources/templates/admin/selectItinerary.html
@@ -44,9 +44,9 @@
                 <input type="hidden" th:name="|legs[${legStatus.index}].toUnLocode|" th:value="${leg.to}"/>
 
                 <input type="hidden" th:name="|legs[${legStatus.index}].fromDate|"
-                       th:value="${#dates.format(leg.loadTime,'yyyy-MM-dd hh:mm')}"/>
+                       th:value="${leg.loadTime}"/>
                 <input type="hidden" th:name="|legs[${legStatus.index}].toDate|"
-                       th:value="${#dates.format(leg.unloadTime,'yyyy-MM-dd hh:mm')}"/>
+                       th:value="${leg.unloadTime}"/>
                 <tr>
                     <td th:text="${leg.voyageNumber}"></td>
                     <td th:text="${leg.from}"></td>

--- a/src/test/java/se/citerus/dddsample/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/se/citerus/dddsample/acceptance/AdminAcceptanceTest.java
@@ -6,6 +6,7 @@ import se.citerus.dddsample.acceptance.pages.AdminPage;
 import se.citerus.dddsample.acceptance.pages.CargoBookingPage;
 import se.citerus.dddsample.acceptance.pages.CargoDestinationPage;
 import se.citerus.dddsample.acceptance.pages.CargoDetailsPage;
+import se.citerus.dddsample.acceptance.pages.CargoRoutingPage;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -51,5 +52,12 @@ public class AdminAcceptanceTest extends AbstractAcceptanceTest {
         cargoDetailsPage = cargoDestinationPage.selectDestinationTo("AUMEL");
         cargoDetailsPage.expectDestinationOf("AUMEL");
         cargoDetailsPage.expectArrivalDeadlineOf(arrivalDeadline);
+
+        // Route cargo
+        cargoDetailsPage.expectRoutedOf("Not routed");
+        CargoRoutingPage cargoRoutingPage = cargoDetailsPage.routeCargo();
+        cargoRoutingPage.expectAtLeastOneRoute();
+        CargoDetailsPage routedCargoDetailsPage = cargoRoutingPage.assignCargoToFirstRoute();
+        routedCargoDetailsPage.expectItinerary();
     }
 }

--- a/src/test/java/se/citerus/dddsample/acceptance/pages/CargoDetailsPage.java
+++ b/src/test/java/se/citerus/dddsample/acceptance/pages/CargoDetailsPage.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CargoDetailsPage {
     public static final String TRACKING_ID_HEADER = "Details for cargo ";
@@ -58,5 +59,22 @@ public class CargoDetailsPage {
         String actualArrivalDeadline = driver.findElement(By.xpath("//div[@id='container']/table/tbody/tr[4]/td[2]")).getText();
 
         assertThat(expectedArrivalDeadline.format(FORMATTER)).isEqualTo(actualArrivalDeadline);
+    }
+
+    public void expectRoutedOf(String routingStatus) {
+        String actualRoutingStatus = driver.findElement(By.xpath("//div[@id='container']/p[2]/strong")).getText();
+
+        assertEquals(routingStatus, actualRoutingStatus);
+    }
+
+    public CargoRoutingPage routeCargo() {
+        driver.findElement(By.linkText("Route this cargo")).click();
+
+        return new CargoRoutingPage(driver, port);
+    }
+
+    public void expectItinerary() {
+        String itineraryText = driver.findElement(By.xpath("//div[@id='container']/table[2]/caption")).getText();
+        assertEquals("Itinerary", itineraryText);
     }
 }

--- a/src/test/java/se/citerus/dddsample/acceptance/pages/CargoRoutingPage.java
+++ b/src/test/java/se/citerus/dddsample/acceptance/pages/CargoRoutingPage.java
@@ -1,0 +1,35 @@
+package se.citerus.dddsample.acceptance.pages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class CargoRoutingPage {
+    private WebDriver driver;
+    private int port;
+
+    public CargoRoutingPage (WebDriver driver, int port) {
+        this.driver = driver;
+        this.port = port;
+
+        WebElement routingHeader = driver.findElement(By.xpath("//h1"));
+        assertThat(routingHeader.getText().equals("Cargo Booking and Routing"));
+    }
+
+    public void expectAtLeastOneRoute() {
+        WebElement assignRouteCaption = driver.findElement(By.cssSelector("form table caption"));
+        assertEquals("Route candidate 1", assignRouteCaption.getText());
+    }
+
+    public CargoDetailsPage assignCargoToFirstRoute() {
+        WebElement assignCargoForm = driver.findElement(By.xpath("//div[@id='container']/form[1]"));
+        assignCargoForm.submit();
+
+        return new CargoDetailsPage(driver, port);
+    }
+
+
+}

--- a/src/test/java/se/citerus/dddsample/interfaces/tracking/ws/CargoTrackingRestServiceIntegrationTest.java
+++ b/src/test/java/se/citerus/dddsample/interfaces/tracking/ws/CargoTrackingRestServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package se.citerus.dddsample.interfaces.tracking.ws;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +17,7 @@ import se.citerus.dddsample.Application;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -28,6 +30,13 @@ public class CargoTrackingRestServiceIntegrationTest {
     private int port;
 
     private final RestTemplate restTemplate = new RestTemplate();
+
+    @BeforeAll
+    static void beforeClass() {
+        // The expected date time values in the resonse are formatted in US locale.
+        // Set the locale in the tests so that they won't fail in non-US locales such as Europe.
+        Locale.setDefault(Locale.US);
+    }
 
     @Transactional
     @Test


### PR DESCRIPTION
### Why <!-- Briefly describe why these changes are needed -->
Fix [issue #99](https://github.com/citerus/dddsample-core/issues/99) error parsing `fromDate` and `toDate` in `RouteAssignmentCommand.LegCommand`. 

### What <!-- Briefly describe how these changes solve the problem -->
1. Change the input param to String in the setters of `fromDate` and `toDate`.
2. Change the date value in thyme leaf page to the original value.
3. In the setters, use `Instant.parse()` to parse the date time in ISO-8601 instant format.
4. Added selenium tests for cargo routing, which tests this change.
5. Set locale to US in CargoTrackingRestServiceIntegrationTest so they can run in non-US regions.