### PR TITLE
Return a UTC ZonedDateTime from CargoRoutingDTO::getArrivalDeadline

### DIFF
--- a/src/main/java/se/citerus/dddsample/interfaces/booking/facade/dto/CargoRoutingDTO.java
+++ b/src/main/java/se/citerus/dddsample/interfaces/booking/facade/dto/CargoRoutingDTO.java
@@ -2,6 +2,9 @@ package se.citerus.dddsample.interfaces.booking.facade.dto;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -67,8 +70,7 @@ public final class CargoRoutingDTO implements Serializable {
     return !legs.isEmpty();
   }
 
-  public Instant getArrivalDeadline() {
-    return arrivalDeadline;
+  public ZonedDateTime getArrivalDeadline() {
+    return arrivalDeadline.atZone(ZoneOffset.UTC);
   }
-
 }

--- a/src/main/resources/templates/admin/show.html
+++ b/src/main/resources/templates/admin/show.html
@@ -30,7 +30,7 @@
         </tr>
         <tr>
             <td>Arrival deadline</td>
-            <td th:text="${#dates.format(cargo.arrivalDeadline,'dd/MM/yyyy')}"/>
+            <td th:text="${#temporals.format(cargo.arrivalDeadline,'dd/MM/yyyy')}"/>
         </tr>
         </tbody>
     </table>

--- a/src/test/java/se/citerus/dddsample/acceptance/pages/CargoDetailsPage.java
+++ b/src/test/java/se/citerus/dddsample/acceptance/pages/CargoDetailsPage.java
@@ -58,7 +58,7 @@ public class CargoDetailsPage {
     public void expectArrivalDeadlineOf(LocalDate expectedArrivalDeadline) {
         String actualArrivalDeadline = driver.findElement(By.xpath("//div[@id='container']/table/tbody/tr[4]/td[2]")).getText();
 
-        assertThat(expectedArrivalDeadline.format(FORMATTER)).isEqualTo(actualArrivalDeadline);
+        assertThat(actualArrivalDeadline).isEqualTo(expectedArrivalDeadline.format(FORMATTER));
     }
 
     public void expectRoutedOf(String routingStatus) {


### PR DESCRIPTION
Internally, the arrivalDeadline assumes a UTC context; but when returning that information to the web client, the timezone information was being stripped away from the value.  This caused the output representation of the arrivalDeadline to be an interpretation of the arrival instant in the user.timezone, rather than in UTC.  Thus under certain conditions an off-by-one error was introduced.

The original version of the admin/show template was using org.thymeleaf.expression.Dates, which was expecting that the arrivalDate in the model would be a java.util.Date.  As a consequence, deep in the call stack the arrivalDate Instant was being converted via Date.from(Instant).  This conversion keeps the instant (epochMillis) constant, but the day/month/year are Date::normalized values, which is to say computed from epochMillis and TimeZone::getDefaultRef....

To eliminate the off by one error, the template is updated to use org.thymeleaf.expression.Temporals::format, which is intended for use with the java.time API.  We then load a ZonedDateTime, rather than an Instant, into the model, ensuring that the output data matches the original input.