### PR TITLE
Fix: domain object's unstable status.

### DIFF
--- a/src/main/java/se/citerus/dddsample/domain/model/cargo/Cargo.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/cargo/Cargo.java
@@ -50,24 +50,24 @@ public class Cargo implements Entity<Cargo> {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
-  public long id;
+  private long id;
 
   @Column(name = "tracking_id", unique = true)
-  public String trackingId;
+  private String trackingId;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "origin_id")
-  public Location origin;
+  private Location origin;
 
   @Embedded
-  public RouteSpecification routeSpecification;
+  private RouteSpecification routeSpecification;
 
   @OneToMany(cascade = CascadeType.ALL)
   @JoinColumn(name = "cargo_id")
-  public List<Leg> itinerary; // TODO figure out if we can map an Itinerary object instead
+  private List<Leg> itinerary; // TODO figure out if we can map an Itinerary object instead
 
   @Embedded
-  public Delivery delivery;
+  private Delivery delivery;
 
   public Cargo(final TrackingId trackingId, final RouteSpecification routeSpecification) {
     Validate.notNull(trackingId, "Tracking ID is required");
@@ -118,6 +118,14 @@ public class Cargo implements Entity<Cargo> {
    */
   public Delivery delivery() {
     return delivery;
+  }
+
+  /**
+   *
+   * @return the id of the cargo, note that the id is not the tracking id.
+   */
+  public long id(){
+    return id;
   }
 
   /**

--- a/src/main/java/se/citerus/dddsample/domain/model/cargo/Delivery.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/cargo/Delivery.java
@@ -26,39 +26,39 @@ import static se.citerus.dddsample.domain.model.cargo.TransportStatus.*;
 public class Delivery implements ValueObject<Delivery> {
 
   @Column
-  public boolean misdirected;
+  private boolean misdirected;
 
   @Column
-  public Instant eta;
+  private Instant eta;
 
   @Column(name = "calculated_at")
-  public Instant calculatedAt;
+  private Instant calculatedAt;
 
   @Column(name = "unloaded_at_dest")
-  public boolean isUnloadedAtDestination;
+  private boolean isUnloadedAtDestination;
 
   @Enumerated(value = EnumType.STRING)
   @Column(name = "routing_status")
-  public RoutingStatus routingStatus;
+  private RoutingStatus routingStatus;
 
   @Embedded
-  public HandlingActivity nextExpectedActivity;
+  private HandlingActivity nextExpectedActivity;
 
   @Enumerated(value = EnumType.STRING)
   @Column(name = "transport_status")
-  public TransportStatus transportStatus;
+  private TransportStatus transportStatus;
 
   @ManyToOne
   @JoinColumn(name = "current_voyage_id")
-  public Voyage currentVoyage;
+  private Voyage currentVoyage;
 
   @ManyToOne()
   @JoinColumn(name = "last_known_location_id")
-  public Location lastKnownLocation;
+  private Location lastKnownLocation;
 
   @ManyToOne
   @JoinColumn(name = "last_event_id")
-  public HandlingEvent lastEvent;
+  private HandlingEvent lastEvent;
 
   private static final Instant ETA_UNKNOWN = null;
   private static final HandlingActivity NO_ACTIVITY = null;

--- a/src/main/java/se/citerus/dddsample/domain/model/cargo/Leg.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/cargo/Leg.java
@@ -19,25 +19,25 @@ public class Leg implements ValueObject<Leg> {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
-  public long id;
+  private long id;
 
   @ManyToOne
   @JoinColumn(name="voyage_id")
-  public Voyage voyage;
+  private Voyage voyage;
 
   @ManyToOne
   @JoinColumn(name = "load_location_id")
-  public Location loadLocation;
+  private Location loadLocation;
 
   @Column(name = "load_time")
-  public Instant loadTime;
+  private Instant loadTime;
 
   @ManyToOne
   @JoinColumn(name = "unload_location_id")
-  public Location unloadLocation;
+  private Location unloadLocation;
 
   @Column(name = "unload_time")
-  public Instant unloadTime;
+  private Instant unloadTime;
 
   public Leg(Voyage voyage, Location loadLocation, Location unloadLocation, Instant loadTime, Instant unloadTime) {
     Validate.noNullElements(new Object[] {voyage, loadLocation, unloadLocation, loadTime, unloadTime});

--- a/src/main/java/se/citerus/dddsample/domain/model/cargo/RouteSpecification.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/cargo/RouteSpecification.java
@@ -23,14 +23,14 @@ public class RouteSpecification extends AbstractSpecification<Itinerary> impleme
 
   @ManyToOne()
   @JoinColumn(name = "spec_origin_id")
-  public Location origin;
+  private Location origin;
 
   @ManyToOne()
   @JoinColumn(name = "spec_destination_id")
-  public Location destination;
+  private Location destination;
 
   @Column(name = "spec_arrival_deadline", nullable = false)
-  public Instant arrivalDeadline;
+  private Instant arrivalDeadline;
 
   /**
    * @param origin origin location - can't be the same as the destination

--- a/src/main/java/se/citerus/dddsample/domain/model/handling/HandlingEvent.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/handling/HandlingEvent.java
@@ -35,29 +35,29 @@ public final class HandlingEvent implements DomainEvent<HandlingEvent> {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
-  public long id;
+  private long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "voyage_id")
-  public Voyage voyage;
+  private Voyage voyage;
 
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "location_id")
-  public Location location;
+  private Location location;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "cargo_id")
-  public Cargo cargo;
+  private Cargo cargo;
 
   @Column
-  public Instant completionTime;
+  private Instant completionTime;
 
   @Column
-  public Instant registrationTime;
+  private Instant registrationTime;
 
   @Column
   @Enumerated(value = EnumType.STRING)
-  public HandlingEvent.Type type;
+  private HandlingEvent.Type type;
 
   /**
    * Handling event type. Either requires or prohibits a carrier movement
@@ -187,6 +187,10 @@ public final class HandlingEvent implements DomainEvent<HandlingEvent> {
 
   public Cargo cargo() {
     return this.cargo;
+  }
+
+  public long id(){
+    return this.id;
   }
 
   @Override

--- a/src/main/java/se/citerus/dddsample/domain/model/location/Location.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/location/Location.java
@@ -17,13 +17,13 @@ public final class Location implements Entity<Location> {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
-  public long id;
+  private long id;
 
   @Column(nullable = false, unique = true, updatable = false)
-  public String unlocode;
+  private String unlocode;
 
   @Column(nullable = false)
-  public String name;
+  private String name;
 
   /**
    * Special Location object that marks an unknown location.
@@ -67,6 +67,14 @@ public final class Location implements Entity<Location> {
     return name;
   }
 
+  public String code() {
+    return unlocode;
+  }
+
+  public long id() {
+    return id;
+  }
+
   /**
    * @param object to compare
    * @return Since this is an entiy this will be true iff UN locodes are equal.
@@ -108,7 +116,4 @@ public final class Location implements Entity<Location> {
     // Needed by Hibernate
   }
 
-  public void setId(long id) {
-    this.id = id;
-  }
 }

--- a/src/main/java/se/citerus/dddsample/domain/model/voyage/CarrierMovement.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/voyage/CarrierMovement.java
@@ -19,21 +19,21 @@ public final class CarrierMovement implements ValueObject<CarrierMovement> {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
-  public long id;
+  private long id;
 
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "arrival_location_id", nullable = false)
-  public Location arrivalLocation;
+  private Location arrivalLocation;
 
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "departure_location_id", nullable = false)
-  public Location departureLocation;
+  private Location departureLocation;
 
   @Column(name = "arrival_time", nullable = false)
-  public Instant arrivalTime;
+  private Instant arrivalTime;
 
   @Column(name = "departure_time", nullable = false)
-  public Instant departureTime;
+  private Instant departureTime;
 
   // Null object pattern 
   public static final CarrierMovement NONE = new CarrierMovement(

--- a/src/main/java/se/citerus/dddsample/domain/model/voyage/Voyage.java
+++ b/src/main/java/se/citerus/dddsample/domain/model/voyage/Voyage.java
@@ -18,14 +18,14 @@ public class Voyage implements Entity<Voyage> {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
-  public long id;
+  private long id;
 
   @Column(name = "voyage_number", unique = true)
-  public String voyageNumber;
+  private String voyageNumber;
 
   @OneToMany(cascade = CascadeType.ALL)
   @JoinColumn(name = "voyage_id")
-  public List<CarrierMovement> carrierMovements;
+  private List<CarrierMovement> carrierMovements;
 
   // Null object pattern
   public static final Voyage NONE = new Voyage(

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/jpa/CargoRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/jpa/CargoRepositoryTest.java
@@ -22,8 +22,6 @@ import se.citerus.dddsample.domain.model.voyage.VoyageRepository;
 import javax.persistence.EntityManager;
 import java.math.BigInteger;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -131,8 +129,8 @@ public class CargoRepositoryTest {
         Cargo result = entityManager.createQuery(
                 String.format("from Cargo c where c.trackingId = '%s'", trackingId.idString()), Cargo.class).getSingleResult();
         assertThat(result.trackingId().idString()).isEqualTo("AAA");
-        assertThat(result.routeSpecification.origin.id).isEqualTo(origin.id);
-        assertThat(result.routeSpecification.destination.id).isEqualTo(destination.id);
+        assertThat(result.routeSpecification().origin().id()).isEqualTo(origin.id());
+        assertThat(result.routeSpecification().destination().id()).isEqualTo(destination.id());
 
         entityManager.clear();
 
@@ -144,7 +142,7 @@ public class CargoRepositoryTest {
     public void testReplaceItinerary() {
         Cargo cargo = cargoRepository.find(new TrackingId("JKL567"));
         assertThat(cargo).isNotNull();
-        long cargoId = cargo.id;
+        long cargoId = cargo.id();
         assertThat(countLegsForCargo(cargoId)).isEqualTo(3);
 
         Location legFrom = locationRepository.find(new UnLocode("FIHEL"));

--- a/src/test/java/se/citerus/dddsample/infrastructure/persistence/jpa/HandlingEventRepositoryTest.java
+++ b/src/test/java/se/citerus/dddsample/infrastructure/persistence/jpa/HandlingEventRepositoryTest.java
@@ -55,14 +55,14 @@ public class HandlingEventRepositoryTest {
 
         flush();
 
-        HandlingEvent result = entityManager.createQuery(String.format("select he from HandlingEvent he where he.id = %d", event.id), HandlingEvent.class).getSingleResult();
+        HandlingEvent result = entityManager.createQuery(String.format("select he from HandlingEvent he where he.id = %d", event.id()), HandlingEvent.class).getSingleResult();
 
-        assertThat(result.cargo.id).isEqualTo(cargo.id);
-        Instant completionDate = result.completionTime;
+        assertThat(result.cargo().id()).isEqualTo(cargo.id());
+        Instant completionDate = result.completionTime();
         assertThat(completionDate).isEqualTo(Instant.ofEpochMilli(10));
-        Instant registrationDate = result.registrationTime;
+        Instant registrationDate = result.registrationTime();
         assertThat(registrationDate).isEqualTo(Instant.ofEpochMilli(20));
-        assertThat(result.type).isEqualTo(HandlingEvent.Type.CLAIM);
+        assertThat(result.type()).isEqualTo(HandlingEvent.Type.CLAIM);
         // TODO: the rest of the columns
     }
 

--- a/src/test/java/se/citerus/dddsample/interfaces/handling/HandlingReportIntegrationTest.java
+++ b/src/test/java/se/citerus/dddsample/interfaces/handling/HandlingReportIntegrationTest.java
@@ -53,7 +53,7 @@ public class HandlingReportIntegrationTest {
                 "completionTime", "2022-10-30T13:37:00",
                 "trackingIds", Collections.singletonList("ABC123"),
                 "type", HandlingEvent.Type.CUSTOMS.name(),
-                "unLocode", SampleLocations.DALLAS.unlocode
+                "unLocode", SampleLocations.DALLAS.unLocode()
         ));
         URI uri = new UriTemplate("http://localhost:{port}/dddsample/handlingReport").expand(port);
         RequestEntity<String> request = RequestEntity
@@ -81,7 +81,7 @@ public class HandlingReportIntegrationTest {
                 "completionTime", "invalid date",
                 "trackingIds", Collections.singletonList("ABC123"),
                 "type", HandlingEvent.Type.CUSTOMS.name(),
-                "unLocode", SampleLocations.STOCKHOLM.unlocode,
+                "unLocode", SampleLocations.STOCKHOLM.code(),
                 "voyageNumber", "0101"
         ));
 


### PR DESCRIPTION
### Why 

Currently the domain objects like Cargo have the public modifier for it's fields.

The domain object should not use public modifier for its field since the client(library user) will change the field, this will cause the domain object has an unstable status.

https://github.com/citerus/dddsample-core/issues/153

### What
- [change] domain object's field modifiers from public to private 
- [change] remove  unexpected setId method for Location
- [change] add some read method for domain objects.
